### PR TITLE
[0.15.1284] fix #109. Update SkillDef-StatDef

### DIFF
--- a/DefInjected/SkillDef/Skills.xml
+++ b/DefInjected/SkillDef/Skills.xml
@@ -1,50 +1,62 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
+	<Shooting.label>Стрельба</Shooting.label>
 	<Shooting.skillLabel>Стрельба</Shooting.skillLabel>
 	<Shooting.pawnLabel>Стрелок</Shooting.pawnLabel>
 	<Shooting.description>Использование всех видов стрелкового оружия.</Shooting.description>
 
+	<Melee.label>Ближний бой</Melee.label>
 	<Melee.skillLabel>Ближний бой</Melee.skillLabel>
 	<Melee.pawnLabel>Драчун</Melee.pawnLabel>
 	<Melee.description>Использование всех видов оружия ближнего боя, а также боя без оружия.</Melee.description>
 
+	<Social.label>Общение</Social.label>
 	<Social.skillLabel>Общение</Social.skillLabel>
 	<Social.pawnLabel>Дипломат</Social.pawnLabel>
 	<Social.description>Ведение переговоров, убеждение, манипуляция, лидерство и возможность подбодрить других.</Social.description>
 
+	<Animals.label>Животноводство</Animals.label>
 	<Animals.skillLabel>Животноводство</Animals.skillLabel>
 	<Animals.pawnLabel>Животновод</Animals.pawnLabel>
 	<Animals.description>Приручение, тренировка, уход и управление животными.</Animals.description>
 
+	<Medicine.label>Медицина</Medicine.label>
 	<Medicine.skillLabel>Медицина</Medicine.skillLabel>
 	<Medicine.pawnLabel>Врач</Medicine.pawnLabel>
 	<Medicine.description>Лечение ранений, заболеваний, а также проведение операций.</Medicine.description>
 
+	<Cooking.label>Кулинария</Cooking.label>
 	<Cooking.skillLabel>Кулинария</Cooking.skillLabel>
 	<Cooking.pawnLabel>Повар</Cooking.pawnLabel>
 	<Cooking.description>Приготовление блюд из сырых ингредиентов.</Cooking.description>
 
+	<Construction.label>Строительство</Construction.label>
 	<Construction.skillLabel>Строительство</Construction.skillLabel>
 	<Construction.pawnLabel>Строитель</Construction.pawnLabel>
 	<Construction.description>От этого навыка зависит скорость строительства и качество мебели.</Construction.description>
 
+	<Growing.label>Фермерство</Growing.label>
 	<Growing.skillLabel>Фермерство</Growing.skillLabel>
 	<Growing.pawnLabel>Фермер</Growing.pawnLabel>
 	<Growing.description>Сбор, посадка и уход за растениями.</Growing.description>
 
+	<Mining.label>Горное дело</Mining.label>
 	<Mining.skillLabel>Горное дело</Mining.skillLabel>
 	<Mining.pawnLabel>Шахтёр</Mining.pawnLabel>
 	<Mining.description>Добыча полезных ресурсов и рытьё тоннелей.</Mining.description>
 
+	<Artistic.label>Искусство</Artistic.label>
 	<Artistic.skillLabel>Искусство</Artistic.skillLabel>
 	<Artistic.pawnLabel>Художник</Artistic.pawnLabel>
 	<Artistic.description>Создание предметов искусства.</Artistic.description>
 
+	<Crafting.label>Ремесло</Crafting.label>
 	<Crafting.skillLabel>Ремесло</Crafting.skillLabel>
 	<Crafting.pawnLabel>Ремесленник</Crafting.pawnLabel>
 	<Crafting.description>Создание обычных предметов, таких как оружие и инструменты.</Crafting.description>
 
+	<Research.label>Исследование</Research.label>
 	<Research.skillLabel>Исследование</Research.skillLabel>
 	<Research.pawnLabel>Учёный</Research.pawnLabel>
 	<Research.description>Проведение исследований, обучение.</Research.description>

--- a/DefInjected/SkillDef/Skills.xml
+++ b/DefInjected/SkillDef/Skills.xml
@@ -1,62 +1,50 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<Shooting.label>Стрельба</Shooting.label>
 	<Shooting.skillLabel>Стрельба</Shooting.skillLabel>
 	<Shooting.pawnLabel>Стрелок</Shooting.pawnLabel>
 	<Shooting.description>Использование всех видов стрелкового оружия.</Shooting.description>
 
-	<Melee.label>Ближний бой</Melee.label>
 	<Melee.skillLabel>Ближний бой</Melee.skillLabel>
 	<Melee.pawnLabel>Драчун</Melee.pawnLabel>
-	<Melee.description>Использование всех видов ближнего оружия, а также рукапашный бой.</Melee.description>
+	<Melee.description>Использование всех видов оружия ближнего боя, а также боя без оружия.</Melee.description>
 
-	<Social.label>Общение</Social.label>
 	<Social.skillLabel>Общение</Social.skillLabel>
 	<Social.pawnLabel>Дипломат</Social.pawnLabel>
 	<Social.description>Ведение переговоров, убеждение, манипуляция, лидерство и возможность подбодрить других.</Social.description>
 
-	<Animals.label>Животноводство</Animals.label>
 	<Animals.skillLabel>Животноводство</Animals.skillLabel>
 	<Animals.pawnLabel>Животновод</Animals.pawnLabel>
 	<Animals.description>Приручение, тренировка, уход и управление животными.</Animals.description>
 
-	<Medicine.label>Медицина</Medicine.label>
 	<Medicine.skillLabel>Медицина</Medicine.skillLabel>
 	<Medicine.pawnLabel>Врач</Medicine.pawnLabel>
 	<Medicine.description>Лечение ранений, заболеваний, а также проведение операций.</Medicine.description>
 
-	<Cooking.label>Кулинария</Cooking.label>
 	<Cooking.skillLabel>Кулинария</Cooking.skillLabel>
 	<Cooking.pawnLabel>Повар</Cooking.pawnLabel>
 	<Cooking.description>Приготовление блюд из сырых ингредиентов.</Cooking.description>
 
-	<Construction.label>Строительство</Construction.label>
 	<Construction.skillLabel>Строительство</Construction.skillLabel>
 	<Construction.pawnLabel>Строитель</Construction.pawnLabel>
 	<Construction.description>От этого навыка зависит скорость строительства и качество мебели.</Construction.description>
 
-	<Growing.label>Фермерство</Growing.label>
 	<Growing.skillLabel>Фермерство</Growing.skillLabel>
 	<Growing.pawnLabel>Фермер</Growing.pawnLabel>
 	<Growing.description>Сбор, посадка и уход за растениями.</Growing.description>
 
-	<Mining.label>Горное дело</Mining.label>
 	<Mining.skillLabel>Горное дело</Mining.skillLabel>
 	<Mining.pawnLabel>Шахтёр</Mining.pawnLabel>
 	<Mining.description>Добыча полезных ресурсов и рытьё тоннелей.</Mining.description>
 
-	<Artistic.label>Искусство</Artistic.label>
 	<Artistic.skillLabel>Искусство</Artistic.skillLabel>
-	<Artistic.pawnLabel>Скульптор</Artistic.pawnLabel>
+	<Artistic.pawnLabel>Художник</Artistic.pawnLabel>
 	<Artistic.description>Создание предметов искусства.</Artistic.description>
 
-	<Crafting.label>Ремесло</Crafting.label>
 	<Crafting.skillLabel>Ремесло</Crafting.skillLabel>
 	<Crafting.pawnLabel>Ремесленник</Crafting.pawnLabel>
 	<Crafting.description>Создание обычных предметов, таких как оружие и инструменты.</Crafting.description>
 
-	<Research.label>Исследование</Research.label>
 	<Research.skillLabel>Исследование</Research.skillLabel>
 	<Research.pawnLabel>Учёный</Research.pawnLabel>
 	<Research.description>Проведение исследований, обучение.</Research.description>

--- a/DefInjected/SpecialThingFilterDef/SpecialThingFilters.xml
+++ b/DefInjected/SpecialThingFilterDef/SpecialThingFilters.xml
@@ -7,9 +7,6 @@
 	<AllowCorpsesStranger.label>чужаков</AllowCorpsesStranger.label>
 	<AllowCorpsesStranger.description>Разрешить складывать сюда мёртвых чужаков и врагов.</AllowCorpsesStranger.description>
 
-	<!--<AllowBuried.label>Захороненные тела</AllowBuried.label>
-	<AllowBuried.description>Разрешить складывать сюда трупы, которые уже были похоронены.</AllowBuried.description>-->
-
 	<AllowRotten.label>гнильё</AllowRotten.label>
 	<AllowRotten.description>Разрешить складывать сюда органические вещи, которые начали гнить.</AllowRotten.description>
 	

--- a/DefInjected/StatCategoryDef/StatCategories.xml
+++ b/DefInjected/StatCategoryDef/StatCategories.xml
@@ -16,8 +16,8 @@
   <!--=============== Virtual categories ==============-->
 
   <EquippedStatOffsets.label>Модификаторы при экипировке</EquippedStatOffsets.label>
-  <StuffStatFactors.label>Множители, если сделано из этого</StuffStatFactors.label>
-  <StuffStatOffsets.label>Модификаторы, если сделано из этого</StuffStatOffsets.label>
+  <StuffStatFactors.label>Множители, если предмет сделан из этого</StuffStatFactors.label>
+  <StuffStatOffsets.label>Модификаторы, если предмет сделано из этого</StuffStatOffsets.label>
   <StuffOfEquipmentStatFactors.label>Множители, если снаряжение сделано из этого</StuffOfEquipmentStatFactors.label>
 
   <!--================ Pawn ================-->

--- a/DefInjected/StatCategoryDef/StatCategories.xml
+++ b/DefInjected/StatCategoryDef/StatCategories.xml
@@ -17,7 +17,7 @@
 
   <EquippedStatOffsets.label>Модификаторы при экипировке</EquippedStatOffsets.label>
   <StuffStatFactors.label>Множители, если предмет сделан из этого</StuffStatFactors.label>
-  <StuffStatOffsets.label>Модификаторы, если предмет сделано из этого</StuffStatOffsets.label>
+  <StuffStatOffsets.label>Модификаторы, если предмет сделан из этого</StuffStatOffsets.label>
   <StuffOfEquipmentStatFactors.label>Множители, если снаряжение сделано из этого</StuffOfEquipmentStatFactors.label>
 
   <!--================ Pawn ================-->

--- a/DefInjected/StatDef/Stats_Basics_General.xml
+++ b/DefInjected/StatDef/Stats_Basics_General.xml
@@ -2,7 +2,7 @@
 <LanguageData>
 
 	<MaxHitPoints.label>максимальная прочность</MaxHitPoints.label>
-	<MaxHitPoints.description>Максимальная прочность объекта. Показывает, сколько урона может претерпеть объект до уничтожения.</MaxHitPoints.description>
+	<MaxHitPoints.description>Максимальная прочность объекта. Показывает, сколько урона может выдержать объект до уничтожения.</MaxHitPoints.description>
 
 	<MarketValue.label>рыночная стоимость</MarketValue.label>
 	<MarketValue.description>Базовая цена объекта на рынке. Реальная стоимость при торговле будет изменена в зависимости от статуса ваших отношений и навыка торговли.</MarketValue.description>

--- a/DefInjected/StatDef/Stats_Basics_General.xml
+++ b/DefInjected/StatDef/Stats_Basics_General.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<MaxHitPoints.label>максимальное здоровье</MaxHitPoints.label>
-	<MaxHitPoints.description>Максимальное здоровье объекта. Показывает, сколько урона может претерпеть объект до уничтожения.</MaxHitPoints.description>
+	<MaxHitPoints.label>максимальная прочность</MaxHitPoints.label>
+	<MaxHitPoints.description>Максимальная прочность объекта. Показывает, сколько урона может претерпеть объект до уничтожения.</MaxHitPoints.description>
 
 	<MarketValue.label>рыночная стоимость</MarketValue.label>
 	<MarketValue.description>Базовая цена объекта на рынке. Реальная стоимость при торговле будет изменена в зависимости от статуса ваших отношений и навыка торговли.</MarketValue.description>

--- a/DefInjected/StatDef/Stats_Building_Special.xml
+++ b/DefInjected/StatDef/Stats_Building_Special.xml
@@ -5,7 +5,7 @@
 	<DoorOpenSpeed.description>Скорость, с которой дверь открывается.</DoorOpenSpeed.description>
 
 	<BedRestEffectiveness.label>эффективность отдыха</BedRestEffectiveness.label>
-	<BedRestEffectiveness.description>Показывает, насколько быстро отдохнут спящие здесь люди.</BedRestEffectiveness.description>
+	<BedRestEffectiveness.description>Показывает, насколько быстро отдохнут спящие на этом объекте люди.</BedRestEffectiveness.description>
 
 	<TrapMeleeDamage.label>урон от ловушки</TrapMeleeDamage.label>
 	<TrapMeleeDamage.description>Средний урон, который может причинить ловушка.</TrapMeleeDamage.description>
@@ -23,7 +23,7 @@
 	<ImmunityGainSpeedFactor.label>фактор скорости иммунизации</ImmunityGainSpeedFactor.label>
 	<ImmunityGainSpeedFactor.description>Скорость иммунизации умножается на это значение.</ImmunityGainSpeedFactor.description>
 
-	<WorkTableWorkSpeedFactor.label>фактор рабочей скорости</WorkTableWorkSpeedFactor.label>
+	<WorkTableWorkSpeedFactor.label>фактор скорости работы</WorkTableWorkSpeedFactor.label>
 	<WorkTableWorkSpeedFactor.description>Скорость работы умножается на это значение.</WorkTableWorkSpeedFactor.description>
 
     <EntertainmentStrengthFactor.label>фактор развлекательной способности</EntertainmentStrengthFactor.label>

--- a/DefInjected/StatDef/Stats_Pawns_Social.xml
+++ b/DefInjected/StatDef/Stats_Pawns_Social.xml
@@ -10,10 +10,10 @@
 	<TrainAnimalChance.label>вероятность обучения животных</TrainAnimalChance.label>
 	<TrainAnimalChance.description>Базовая вероятность, с которой этот персонаж продвинется в тренировке животного. Может варьироваться в зависимости от животного.</TrainAnimalChance.description>
 
-	<SocialImpact.label>влияние разговоров</SocialImpact.label>
+	<SocialImpact.label>социальное влияние</SocialImpact.label>
 	<SocialImpact.description>Социальное влияние персонажа на других при общении.</SocialImpact.description>
 
-	<GiftImpact.label>влияние подарков</GiftImpact.label>
+	<GiftImpact.label>влияние дипломатических подарков</GiftImpact.label>
 	<GiftImpact.description>Когда персонаж дарит подарки другой фракции, этот множитель применяется к их влиянию на отношения с этой фракцией.</GiftImpact.description>
 
 	<TradePriceImprovement.label>улучшение торговой цены</TradePriceImprovement.label>

--- a/DefInjected/StatDef/Stats_Pawns_WorkGeneral.xml
+++ b/DefInjected/StatDef/Stats_Pawns_WorkGeneral.xml
@@ -17,7 +17,7 @@
 	<ConstructionSpeed.description>Скорость, с которой персонаж строит и ремонтирует здания.</ConstructionSpeed.description>
 
 	<PlantWorkSpeed.label>скорость работы с растениями</PlantWorkSpeed.label>
-	<PlantWorkSpeed.description>Скорость, с которой персонаж сеет и собирает растения.</PlantWorkSpeed.description>
+	<PlantWorkSpeed.description>Скорость, с которой персонаж сажает растения и собирает урожай.</PlantWorkSpeed.description>
 
 	<HarvestFailChance.label>вероятность уничтожить урожай</HarvestFailChance.label>
 	<HarvestFailChance.description>Вероятность, с которой персонаж уничтожит урожай вместо сбора.</HarvestFailChance.description>
@@ -26,6 +26,6 @@
 	<ConstructFailChance.description>Вероятность того, что персонажу не удастся создать постройку, потратив впустую время и ресурсы.</ConstructFailChance.description>
 
 	<FixBrokenDownBuildingFailChance.label>вероятность неудачного ремонта</FixBrokenDownBuildingFailChance.label>
-    <FixBrokenDownBuildingFailChance.description>Вероятность, с которой персонажу не удастрся починить механизм.</FixBrokenDownBuildingFailChance.description>
+    <FixBrokenDownBuildingFailChance.description>Вероятность, с которой персонажу не удастся починить постройку.</FixBrokenDownBuildingFailChance.description>
 
 </LanguageData>

--- a/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
+++ b/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
@@ -12,8 +12,8 @@
 	<SmithingSpeed.label>скорость ковки</SmithingSpeed.label>
 	<SmithingSpeed.description>Скорость, с которой персонаж куёт или изготавливает оружие, механизмы, боеприпасы и инструменты.</SmithingSpeed.description>
 
-	<DrugProductionSpeed.label>скорость производства наркотиков</DrugProductionSpeed.label>
-	<DrugProductionSpeed.description>Скорость, с которой персонаж производит наркотики.</DrugProductionSpeed.description>
+	<DrugProductionSpeed.label>скорость производства наркотиков и медикаментов</DrugProductionSpeed.label>
+	<DrugProductionSpeed.description>Скорость, с которой персонаж производит наркотики и медикаменты.</DrugProductionSpeed.description>
 	
 	<!-- Production recipes - speed affected by skill.-->
 

--- a/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
+++ b/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
@@ -12,6 +12,9 @@
 	<SmithingSpeed.label>скорость ковки</SmithingSpeed.label>
 	<SmithingSpeed.description>Скорость, с которой персонаж куёт или изготавливает оружие, механизмы, боеприпасы и инструменты.</SmithingSpeed.description>
 
+	<DrugProductionSpeed.label>скорость производства наркотиков</DrugProductionSpeed.label>
+	<DrugProductionSpeed.description>Скорость, с которой персонаж производит наркотики.</DrugProductionSpeed.description>
+	
 	<!-- Production recipes - speed affected by skill.-->
 
 	<CookSpeed.label>скорость приготовления еды</CookSpeed.label>

--- a/DefInjected/StatDef/Stats_Weapons_Melee.xml
+++ b/DefInjected/StatDef/Stats_Weapons_Melee.xml
@@ -10,10 +10,10 @@
 	
 	<!-- Damage multipliers should be stats on stuffs only-->
 
-	<SharpDamageMultiplier.label>острое оружие</SharpDamageMultiplier.label>
+	<SharpDamageMultiplier.label>проникающий урон</SharpDamageMultiplier.label>
 	<SharpDamageMultiplier.description>Множитель к урону от колющих и режущих атак, который будет наносить предмет, сделанный из этого материала.</SharpDamageMultiplier.description>
 
-	<BluntDamageMultiplier.label>тупое оружие</BluntDamageMultiplier.label>
-	<BluntDamageMultiplier.description>Множитель к урону от тупых ударов, который будет наносить предмет, сделанный из этого материала.</BluntDamageMultiplier.description>
+	<BluntDamageMultiplier.label>дробящий урон</BluntDamageMultiplier.label>
+	<BluntDamageMultiplier.description>Множитель к урону от дробящих ударов, который будет наносить предмет, сделанный из этого материала.</BluntDamageMultiplier.description>
 
 </LanguageData>

--- a/DefInjected/StatDef/Stats_Weapons_Melee.xml
+++ b/DefInjected/StatDef/Stats_Weapons_Melee.xml
@@ -10,10 +10,10 @@
 	
 	<!-- Damage multipliers should be stats on stuffs only-->
 
-	<SharpDamageMultiplier.label>режущий урон</SharpDamageMultiplier.label>
-	<SharpDamageMultiplier.description>Множитель к проникающему урону в ближнем бою, который будет наносить предмет, сделанный из этого материала.</SharpDamageMultiplier.description>
+	<SharpDamageMultiplier.label>острое оружие</SharpDamageMultiplier.label>
+	<SharpDamageMultiplier.description>Множитель к урону от колющих и режущих атак, который будет наносить предмет, сделанный из этого материала.</SharpDamageMultiplier.description>
 
-	<BluntDamageMultiplier.label>тупой урон</BluntDamageMultiplier.label>
-	<BluntDamageMultiplier.description>Множитель к тупому урону в ближнем бою, который будет наносить предмет, сделанный из этого материала.</BluntDamageMultiplier.description>
+	<BluntDamageMultiplier.label>тупое оружие</BluntDamageMultiplier.label>
+	<BluntDamageMultiplier.description>Множитель к урону от тупых ударов, который будет наносить предмет, сделанный из этого материала.</BluntDamageMultiplier.description>
 
 </LanguageData>


### PR DESCRIPTION
Пункты приведены в соотвествии с [актуальным заданием](https://github.com/Ludeon/RimWorld-ru/issues/109#issuecomment-246204816)

1) Удалены неиспользуемые тэги в **~Russian\DefInjected\SkillDef\Skills.xml**
Так же доработан перевод в нескольких местах.

2) Удалены закомментированные строки в **~Russian\DefInjected\SpecialThingFilterDef\SpecialThingFilter.xml**

3) Доработан перевод для **`<StuffStatFactors.label>`** и **`<StuffStatOffsets.label>`**

5) Изменен перевод объекта "**MaxHitPoints**", т.к. у предметов не может быть здоровья.

6) Доработан перевод объектов **BedRestEffectiveness** и **WorkTableWorkSpeedFactor**.

8) Доработан перевод объектов **SocialImpact** и **GiftImpact**.

9) Доработан перевод объекта **PlantWorkSpeed**
Доработан перевод объекта **FixBrokenDownBuildingFailChance** в соответствии с оригиналом:
"The chance that this person will fail to repair a broken down building."
Исправлена опечатка "**удастрся**" -> "**удастся**".

10) Добавлен перевод объекта **DrugProductionSpeed**.
Перевод сделан согласованным с прочими подобными объектами из этого файла.
Слово "**Drugs**" переведено как "**наркотики**", возможно стоит перевести как "**препараты**"

11) Переделан перевод объектов **SharpDamageMultiplier** и **BluntDamageMultiplier**
Обратите особое внимание.