### PR TITLE
[0.15.1284] fix #157. Fix DoBillsProduceDrugs tags.

### DIFF
--- a/DefInjected/WorkGiverDef/WorkGivers.xml
+++ b/DefInjected/WorkGiverDef/WorkGivers.xml
@@ -251,7 +251,7 @@
 
   <DoBillsProduceDrugs.label>изготавливать препараты</DoBillsProduceDrugs.label>
   <DoBillsProduceDrugs.gerund>Изготавливать препараты, используя</DoBillsProduceDrugs.gerund>
-  <DoBillsProduceDrugs.label>изготавливать препараты на</DoBillsProduceDrugs.label>
+  <DoBillsProduceDrugs.verb>изготавливать препараты на</DoBillsProduceDrugs.verb>
   
   <DoBillsSmelter.label>плавить предметы</DoBillsSmelter.label>
   <DoBillsSmelter.gerund>Плавить, используя</DoBillsSmelter.gerund>


### PR DESCRIPTION
Исправил ошибку в названии тэгов. Раньше было 2 лейбла.