### PR TITLE
[0.15.1284] fix #101. Fix HediffDef-HediffGiverSetDef.

### DIFF
--- a/DefInjected/HediffDef/Hediffs_Global_Drugs.xml
+++ b/DefInjected/HediffDef/Hediffs_Global_Drugs.xml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<Alcohol.label>алкоголь</Alcohol.label>
-	<Alcohol.stages.0.label>почти трезв</Alcohol.stages.0.label>
-	<Alcohol.stages.1.label>навеселе</Alcohol.stages.1.label>
-	<Alcohol.stages.2.label>подвыпивший</Alcohol.stages.2.label>
-	<Alcohol.stages.3.label>пьяный</Alcohol.stages.3.label>
-	<Alcohol.stages.4.label>сильно пьяный</Alcohol.stages.4.label>
-	<Alcohol.stages.5.label>без сознания</Alcohol.stages.5.label>
+	<AlcoholHigh.label>алкоголь</AlcoholHigh.label>
+	<AlcoholHigh.stages.0.label>почти трезв</AlcoholHigh.stages.0.label>
+	<AlcoholHigh.stages.1.label>навеселе</AlcoholHigh.stages.1.label>
+	<AlcoholHigh.stages.2.label>подвыпивший</AlcoholHigh.stages.2.label>
+	<AlcoholHigh.stages.3.label>пьяный</AlcoholHigh.stages.3.label>
+	<AlcoholHigh.stages.4.label>сильно пьяный</AlcoholHigh.stages.4.label>
+	<AlcoholHigh.stages.5.label>без сознания</AlcoholHigh.stages.5.label>
 
 	<Hangover.label>похмелье</Hangover.label>
 	<Hangover.stages.0.label>лёгкое</Hangover.stages.0.label>

--- a/DefInjected/HediffDef/Hediffs_Global_Misc.xml
+++ b/DefInjected/HediffDef/Hediffs_Global_Misc.xml
@@ -9,9 +9,13 @@
 	<BloodLoss.stages.4.label>огромная</BloodLoss.stages.4.label>
 
 	<Anesthetic.label>наркоз</Anesthetic.label>
+
 	<Concussion.label>сотрясение мозга</Concussion.label>
+
 	<CryptosleepSickness.label>крипто-сонная болезнь</CryptosleepSickness.label>
+
 	<PsychicShock.label>психический шок</PsychicShock.label>
+
 	<FoodPoisoning.label>пищевое отравление</FoodPoisoning.label>
 
 	<ToxicBuildup.label>химический ожог</ToxicBuildup.label>
@@ -33,5 +37,12 @@
 	<HeartAttack.stages.0.label>болезненный</HeartAttack.stages.0.label>
 	<HeartAttack.stages.1.label>ослабляющий</HeartAttack.stages.1.label>
 	<HeartAttack.stages.2.label>смертельный</HeartAttack.stages.2.label>
+
+	<DrugOverdose.label>передозировка</DrugOverdose.label>
+	<DrugOverdose.comps.1.discoverLetterLabel>Передозировка: {0}</DrugOverdose.comps.1.discoverLetterLabel>
+	<DrugOverdose.comps.1.discoverLetterText>У {0} передозировка!</DrugOverdose.comps.1.discoverLetterText>
+	<DrugOverdose.stages.0.label>скрытая</DrugOverdose.stages.0.label>
+	<DrugOverdose.stages.1.label>небольшая</DrugOverdose.stages.1.label>
+	<DrugOverdose.stages.2.label>сильная</DrugOverdose.stages.2.label>
 
 </LanguageData>

--- a/DefInjected/HediffDef/Hediffs_Local_Chronic.xml
+++ b/DefInjected/HediffDef/Hediffs_Local_Chronic.xml
@@ -26,12 +26,12 @@
   <HeartArteryBlockage.stages.4.label>тяжёлый</HeartArteryBlockage.stages.4.label>
   <HeartArteryBlockage.stages.5.label>экстремальный</HeartArteryBlockage.stages.5.label>
   
-  <Carcinoma.label>рак</Carcinoma.label>
-  <Carcinoma.stages.0.label>начальный</Carcinoma.stages.0.label>
-  <Carcinoma.stages.1.label>лёгкий</Carcinoma.stages.1.label>
-  <Carcinoma.stages.2.label>средний</Carcinoma.stages.2.label>
-  <Carcinoma.stages.3.label>тяжёлый</Carcinoma.stages.3.label>
-  <Carcinoma.stages.4.label>экстремальный</Carcinoma.stages.4.label>
+  <Carcinoma.label>карцинома</Carcinoma.label>
+  <Carcinoma.stages.0.label>начальная</Carcinoma.stages.0.label>
+  <Carcinoma.stages.1.label>лёгкая</Carcinoma.stages.1.label>
+  <Carcinoma.stages.2.label>средняя</Carcinoma.stages.2.label>
+  <Carcinoma.stages.3.label>тяжёлая</Carcinoma.stages.3.label>
+  <Carcinoma.stages.4.label>экстремальная</Carcinoma.stages.4.label>
   <Carcinoma.stages.5.label>последняя стадия</Carcinoma.stages.5.label>
 
 </LanguageData>

--- a/DefInjected/HediffDef/Hediffs_Local_Infections.xml
+++ b/DefInjected/HediffDef/Hediffs_Local_Infections.xml
@@ -10,7 +10,7 @@
   <FibrousMechanites.stages.0.label>умеренная боль</FibrousMechanites.stages.0.label>
   <FibrousMechanites.stages.1.label>сильная боль</FibrousMechanites.stages.1.label>
   
-  <SensoryMechanites.label>нейронные механиты</SensoryMechanites.label>
+  <SensoryMechanites.label>сенсо́рные механиты</SensoryMechanites.label>
   <SensoryMechanites.stages.0.label>умеренная боль</SensoryMechanites.stages.0.label>
   <SensoryMechanites.stages.1.label>сильная боль</SensoryMechanites.stages.1.label>
 

--- a/DefInjected/HediffDef/Hediffs_Local_Injuries.xml
+++ b/DefInjected/HediffDef/Hediffs_Local_Injuries.xml
@@ -21,7 +21,7 @@
   <Burn.injuryProps.destroyedLabel>сгорело</Burn.injuryProps.destroyedLabel>
   <Burn.injuryProps.destroyedOutLabel>сгорело</Burn.injuryProps.destroyedOutLabel>
 
-  <Crush.label>перелом</Crush.label>
+  <Crush.label>размозжённая рана</Crush.label>
   <Crush.comps.0.labelTendedWell>перевязано</Crush.comps.0.labelTendedWell>
   <Crush.comps.0.labelTended>плохо перевязано</Crush.comps.0.labelTended>
   <Crush.comps.0.labelTendedWellInner>зашито</Crush.comps.0.labelTendedWellInner>
@@ -29,16 +29,16 @@
   <Crush.comps.0.labelSolidTendedWell>обработано</Crush.comps.0.labelSolidTendedWell>
   <Crush.comps.0.labelSolidTended>плохо обработано</Crush.comps.0.labelSolidTended>
   <Crush.comps.2.oldLabel>шрам</Crush.comps.2.oldLabel>
-  <Crush.injuryProps.destroyedLabel>сломано</Crush.injuryProps.destroyedLabel>
+  <Crush.injuryProps.destroyedLabel>раздавлено</Crush.injuryProps.destroyedLabel>
 
-  <Crack.label>трещина</Crack.label>
+  <Crack.label>перелом</Crack.label>
   <Crack.comps.0.labelTendedWell>вылечено</Crack.comps.0.labelTendedWell>
   <Crack.comps.0.labelTended>плохо вылечено</Crack.comps.0.labelTended>
   <Crack.comps.0.labelTendedWellInner>вылечено</Crack.comps.0.labelTendedWellInner>
   <Crack.comps.0.labelTendedInner>плохо вылечено</Crack.comps.0.labelTendedInner>
   <Crack.comps.0.labelSolidTendedWell>обработано</Crack.comps.0.labelSolidTendedWell>
   <Crack.comps.0.labelSolidTended>плохо обработано</Crack.comps.0.labelSolidTended>
-  <Crack.injuryProps.destroyedLabel>треснуто</Crack.injuryProps.destroyedLabel>
+  <Crack.injuryProps.destroyedLabel>раздроблено</Crack.injuryProps.destroyedLabel>
 
   <Cut.label>порез</Cut.label>
   <Cut.comps.0.labelTendedWell>перевязано</Cut.comps.0.labelTendedWell>

--- a/DefInjected/HediffDef/Hediffs_Local_Injuries.xml
+++ b/DefInjected/HediffDef/Hediffs_Local_Injuries.xml
@@ -59,8 +59,6 @@
   <SurgicalCut.comps.0.labelSolidTendedWell>обработано</SurgicalCut.comps.0.labelSolidTendedWell>
   <SurgicalCut.comps.0.labelSolidTended>плохо обработано</SurgicalCut.comps.0.labelSolidTended>
   <SurgicalCut.comps.1.oldLabel>шрам от пореза</SurgicalCut.comps.1.oldLabel>
-<!--<SurgicalCut.injuryProps.destroyedLabel>отрезано</SurgicalCut.injuryProps.destroyedLabel>
-  <SurgicalCut.injuryProps.destroyedOutLabel>вырезано</SurgicalCut.injuryProps.destroyedOutLabel>-->
 
   <Scratch.label>царапина</Scratch.label>
   <Scratch.comps.0.labelTendedWell>перевязано</Scratch.comps.0.labelTendedWell>
@@ -107,7 +105,7 @@
   <Gunshot.injuryProps.destroyedLabel>отстрелено</Gunshot.injuryProps.destroyedLabel>
   <Gunshot.injuryProps.destroyedOutLabel>прострелено</Gunshot.injuryProps.destroyedOutLabel>
 
-  <Shredded.label>раздроблено взрывом</Shredded.label>
+  <Shredded.label>взрывная травма</Shredded.label>
   <Shredded.comps.0.labelTendedWell>перевязано</Shredded.comps.0.labelTendedWell>
   <Shredded.comps.0.labelTended>плохо перевязано</Shredded.comps.0.labelTended>
   <Shredded.comps.0.labelTendedWellInner>зашито</Shredded.comps.0.labelTendedWellInner>
@@ -118,7 +116,7 @@
   <Shredded.injuryProps.destroyedLabel>оторвано</Shredded.injuryProps.destroyedLabel>
   <Shredded.injuryProps.destroyedOutLabel>разорвано</Shredded.injuryProps.destroyedOutLabel>
 
-  <Bruise.label>ушиб</Bruise.label>
+  <Bruise.label>синяк</Bruise.label>
   <Bruise.comps.0.labelTendedWell>перевязано</Bruise.comps.0.labelTendedWell>
   <Bruise.comps.0.labelTended>плохо перевязано</Bruise.comps.0.labelTended>
   <Bruise.comps.0.labelTendedWellInner>зашито</Bruise.comps.0.labelTendedWellInner>


### PR DESCRIPTION
Актуальное задание:

1) **HediffDef\Hediffs_Global_Drugs.xml**
Объект **Alcohol** теперь называется **AlcoholHigh**. Переименовать соответственно.

2) **HediffDef\Hediffs_Global_Misc.xml**
Добавить перевод для объекта **DrugOverdose**.

3) **HediffDef\Hediffs_Local_Chronic.xml**
Опционально: поправить перевод объекта **Carcinoma**
"**Carcinoma**" переведена как "**рак**", хотя "**карцинома**" это отдельный его вид.

4) **HediffDef\Hediffs_Local_Infections.xml**
Опционально: поправить перевод объекта **SensoryMechanites**.
"**Sensory mechanites**" переведено как "**нейронные механиты**".

5) **HediffDef\Hediffs_Local_Injuries.xml**
Под вопросом: "**Crush**" переведено как "**перелом**".
Удалить перевод группы **injuryProps** у объекта **SurgicalCut**, т.к. у него нет таких тэгов.
Под вопросом: "**Shredded**" переведено как "**раздроблено взрывом**"