### PR TITLE
﻿Improve README by adding information about non-Windows OS paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 `<путь к папке игры>` для Steam версии в различных ОС:
     * Windows: `C:\Program Files (x86)\Steam\SteamApps\common\RimWorld\`
     * Linux: `~/.steam/steam/steamapps/common/Rimworld`
-    * Mac: `~/Library/Application\ Support/Steam/steamapps/common/RimWorld/RimWorldMac.app` (для дальнейшей навигации выбрать пункт контекстного меню «Показать содержимое пакета»).
+    * Mac: `~/Library/Application Support/Steam/steamapps/common/RimWorld/RimWorldMac.app` (для дальнейшей навигации выбрать пункт контекстного меню «Показать содержимое пакета»).
 
     Таким образом, для Steam-версии в ОС Windows полный путь может выглядеть примерно вот так:  
     `C:\Program Files (x86)\Steam\SteamApps\common\RimWorld\Mods\Core\Languages\RimWorld-ru-master`  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RimWorld-RU
+﻿# RimWorld-RU
 ﻿Здравствуйте, уважаемые игроки RimWorld!
 
 В данном репозитории лежит не что иное, как официальная русская локализация RimWorld. Именно из этого репозитория русский перевод попадает в игру с каждым выходом очередного обновления.
@@ -11,17 +11,26 @@
 	* A-16: [архив](https://github.com/Ludeon/RimWorld-ru/archive/alpha-16.zip), [Git-репозиторий](https://github.com/Ludeon/RimWorld-ru/tree/alpha-16)
 	* A-15: [архив](https://github.com/Ludeon/RimWorld-ru/archive/alpha-15.zip), [Git-репозиторий](https://github.com/Ludeon/RimWorld-ru/tree/alpha-15)
 2. Переместить папку перевода по пути:
-`<путь к папке игры>\Mods\Core\Languages\`.
-Для Steam-версии путь может выглядеть примерно вот так:
-`C:\Program Files (x86)\Steam\SteamApps\common\RimWorld\Mods\Core\Languages\RimWorld-ru-master`.
-Предварительно следует удалить имеющуюся папку Russian.
-3. В игре заново выбрать русский язык
+`<путь к папке игры>\Mods\Core\Languages\`.  
+`<путь к папке игры>` для Steam версии в различных ОС:
+    * Windows: `C:\Program Files (x86)\Steam\SteamApps\common\RimWorld\`
+    * Linux: `~/.steam/steam/steamapps/common/Rimworld`
+    * Mac: `~/Library/Application\ Support/Steam/steamapps/common/RimWorld/RimWorldMac.app` (для дальнейшей навигации выбрать пункт контекстного меню «Показать содержимое пакета»).
+
+    Таким образом, для Steam-версии в ОС Windows полный путь может выглядеть примерно вот так:  
+    `C:\Program Files (x86)\Steam\SteamApps\common\RimWorld\Mods\Core\Languages\RimWorld-ru-master`  
+    Предварительно следует удалить имеющуюся папку Russian.
+3. В игре заново выбрать русский язык.
 4. Периодически проверять наличие обновлений.
 
-В случае возникновения ошибки (чёрный экран, красный текст), необходимо сделать следующее:
+В случае возникновения ошибки (чёрный экран, красный текст) необходимо сделать следующее:
 
-1. Из папки `C:\Users\~имя пользователя~\AppData\LocalLow\Ludeon Studios\RimWorld by Ludeon Studios\Config` удалить файл Prefs.xml и, возможно, ModsConfig.xml (если вы играете без модов, то это ничем не повредит, если играете с модами, то, скорее всего, сами разберётесь, как лучше будет поступить с этим файлом).
-2. В игре выбрать русский язык.
+1. Перейти в папку `Config`:
+    * Windows: `C:\Users\~имя пользователя~\AppData\LocalLow\Ludeon Studios\RimWorld by Ludeon Studios\Config`
+    * Linux: `~/.config/unity3d/Ludeon Studios/RimWorld/Config`
+    * Mac: `~/Library/Application Support/RimWorld/Config`
+2. Из этой папки удалить файл `Prefs.xml` и, возможно, `ModsConfig.xml` (если вы играете без модов, то это ничем не повредит, если играете с модами, то, скорее всего, сами разберётесь, как лучше будет поступить с этим файлом).
+3. В игре выбрать русский язык.
 
 ## Официальные переводчики:
 * [Elevator89](https://github.com/Elevator89)


### PR DESCRIPTION
Данный PR добавляет в README информацию о путях установки локализации и конфигурационных файлов для Linux и macOS систем, что облегчит задачу установки локализации для не-Windows пользователей. Пути для macOS взяты из собственного опыта и из [RimWorld wiki](http://rimworldwiki.com/wiki/Installing_mods), пути для Linux-систем взяты из той же вики.
Также не смог пройти мимо некоторых моментов форматирования (перенос строки в списке, подсветка имени файлов) и пунктуации (L26), однако, если вы решите, что эти вещи лучше поправить в отдельном PR, let it be so.
