### PR TITLE
Remove disambiguity of the word "ботаник"

### DIFF
--- a/Backstories/Backstories.xml
+++ b/Backstories/Backstories.xml
@@ -632,7 +632,7 @@
 
 	<BiosphereManager95>
 		<title>менеджер по биосфере</title>
-		<titleShort>ботаник</titleShort>
+		<titleShort>садовник</titleShort>
 		<desc>Много лет {PAWN_nameDef} живёт в утопическом мире, где всю чёрную работу выполняют роботы, а люди ведут праздный образ жизни. {PAWN_pronoun} отвечает за флору и фауну в цветущем парке, куда граждане приходят созерцать красоту живой природы.</desc>
 	</BiosphereManager95>
 
@@ -2343,8 +2343,8 @@
 
 	<?solid Christian "Christian" Morris (Male) ?>
 	<AmateurBotanist14>
-		<title>юный ботаник</title>
-		<titleShort>ботаник</titleShort>
+		<title>садовод-любитель</title>
+		<titleShort>садовод</titleShort>
 		<desc>Проведя юные годы, копаясь в земле, {PAWN_nameDef} обнаруживает в себе талант к садоводству. Вместо того, чтобы учиться готовить выращенную еду, {PAWN_pronoun} предпочитает выращивать ещё и ещё.</desc>
 	</AmateurBotanist14>
 
@@ -2573,7 +2573,7 @@
 	<?solid Ian Braddock (Male) ?>
 	<PoisonGardener29>
 		<title>ядовитый садовник</title>
-		<titleShort>ботаник</titleShort>
+		<titleShort>садовник</titleShort>
 		<desc>{PAWN_nameDef} почти всё своё время ухаживает за ядовитым садом, при этом отдалившись от общества.
 
 За этот срок {PAWN_pronoun} обучается кое-какому безопасному кулинарному и лекарственному применению разных смертоносных растений.</desc>
@@ -5579,7 +5579,7 @@
 
 	<?solid Brazos "Braz" Wheeler (Male) ?>
 	<SpaceNerd97>
-		<title>космоботаник</title>
+		<title>фанат космоса</title>
 		<titleShort>ботаник</titleShort>
 		<desc>{PAWN_nameDef} хочет стать, как {PAWN_possessive} любимый супергерой Мистер Мощь. {PAWN_pronoun} мечтает о путешествиях меж звёзд и исследовании новых миров. Также {PAWN_pronoun} постоянно грезит о шоколаде... космическом шоколаде.</desc>
 	</SpaceNerd97>


### PR DESCRIPTION
Сделано по жалобе одного игрока, котрому не нравится использование в биографиях слова "ботаник" в двух различных значениях.