### PR TITLE
Fix line 200

### DIFF
--- a/Keyed/ITabs.xml
+++ b/Keyed/ITabs.xml
@@ -197,7 +197,7 @@
   <!-- EN: Requires trainability {0}. -->
   <CannotTrainNotSmartEnough>Требуется способность к обучению: {0}.</CannotTrainNotSmartEnough>
   <!-- EN: {1_labelShort} is too small to train this. -->
-  <CannotTrainTooSmall>{1_labelShort} — не подходящего возраста, чтобы обучаться этому.</CannotTrainTooSmall>
+  <CannotTrainTooSmall>{1_labelShort} — неподходящего размера, чтобы обучаться этому.</CannotTrainTooSmall>
 
   <!-- EN: Prerequisite needed: {0} -->
   <TrainingNeedsPrerequisite>Требуется: {0}</TrainingNeedsPrerequisite>


### PR DESCRIPTION

![screenshot-fox](https://user-images.githubusercontent.com/46885477/74588477-a7a3eb00-501e-11ea-9a57-3387e283fb87.jpg)
Лисица (старая) не обучается спасению, по причине "неподходящего возраста", см. скриншот. По-моему, в данном случае Too small правильнее перевести "неподходящего размера". И здесь "не" пишется слитно.

PS: строку 293 я не менял, вероятно автоматика гитхаба сработала.