### PR TITLE
#990 Translate_Royalty_QuestScriptDef_5

### DIFF
--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Joiners.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Joiners.xml
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+  
+  <!-- EN:
+    <li>lodgersLabel-></li>
+    <li>lodgersLabelPlural->guests</li>
+  -->
+  <Hospitality_Joiners.questDescriptionAndNameRules.rulesStrings>
+    <li>lodgersLabel->задание</li>
+    <li>lodgersLabelPlural->задания</li>
+  </Hospitality_Joiners.questDescriptionAndNameRules.rulesStrings>
+  <!-- EN:
+    <li>lodgersDef(lodgersCount==1)->[lodgers0_nameDef]</li>
+    <li>lodgersDef(lodgersCount>=2)->the guests</li>
+    <li>joinerEnding->You'll be able to direct [lodgersDef] the same way you direct your own colonists.[specialNeedsExplanation]</li>
+    <li>specialNeedsExplanation(asker_royalInCurrentFaction==True,priority=1)-> You'll need to satisfy any special royal needs the guests may have.</li>
+    <li>specialNeedsExplanation-></li>
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->A [lodgers0_title] named [lodgers0_nameFull] wants you to protect [lodgers0_objective] at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] was recently caught [wrongAct]. Seeking revenge, [enemyFaction_pawnsPlural] will come for [lodgers0_objective] as long as [lodgers0_pronoun] is with you. [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo1(generateThreats==false)-></li>
+    <li>wrongAct->insulting the [PersonalCharacteristic] of [enemyFaction_leader_nameDef], [enemyFaction_leaderTitle] of [enemyFaction_name]</li>
+    <li>wrongAct->stealing livestock from [enemyFaction_name]</li>
+    <li>wrongAct->stealing food from [enemyFaction_name]</li>
+    <li>wrongAct->stealing spiritual artifacts from [enemyFaction_name]</li>
+    <li>wrongAct->sabotaging the cryptosleep caskets of [enemyFaction_name]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->A group of [lodgersCount] travelers want you to host them at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo2]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nThese travelers were recently invited to an important ceremony with [enemyFaction_name], but showed up drunk and profaned the ritual. [enemyFaction_name] is now sending raids after them. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsMultiHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\nThe travelers recently [mechViolation], and have been targeted by an orbiting mechanoid swarm. As long as they are present, mechanoid clusters will drop from orbit on a regular basis.</li>
+    <li>threatsInfo2(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==false)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name] is requesting a favor. [asker_possessive] friend [lodgers0_nameFull] is interested in learning about other cultures. [asker_nameDef] wants you to host [lodgers0_nameDef] at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name] is requesting a favor. [asker_possessive] friend, a [lodgers0_age]-year-old [lodgers0_title] named [lodgers0_nameDef], was caught writing vicious insults about [enemyFaction_leader_nameFull]'s [PersonalCharacteristic]. [asker_nameDef] is asking for you to guard [lodgers0_nameDef] for [shuttleDelayTicks_duration], until [asker_pronoun] can smooth over relations with [enemyFaction_name]. [allLodgerInfo]\n\nSince [enemyFaction_leader_nameDef] is the [enemyFaction_leaderTitle] of [enemyFaction_name], [enemyFaction_leader_pronoun] has sent groups of [enemyFaction_pawnsPlural] to hunt the insulter [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name] is requesting a favor. [asker_possessive] friend, a [lodgers0_age]-year-old [lodgers0_title] named [lodgers0_nameDef], recently [mechViolation]. [asker_nameDef] is asking for you to guard [lodgers0_nameDef] for [shuttleDelayTicks_duration], until [asker_pronoun] can sooth the mechanoid hive. [allLodgerInfo]\n\nMechanoids will come to hunt the violator [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==MechClusters)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name] is requesting a favor. [asker_possessive] friend, a [lodgers0_age]-year-old [lodgers0_title] named [lodgers0_nameDef], recently [mechViolation]. [asker_nameDef] is asking for you to guard [lodgers0_nameDef] for [shuttleDelayTicks_duration]. Mechanoid clusters will arrive as long as [lodgers0_nameDef] is present. [allLodgerInfo][threatsInfo1] [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==false)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], recently rescued [lodgersCount] [asker_faction_pawnsPlural] from an enemy jail. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], recently rescued [lodgersCount] [asker_faction_pawnsPlural] from the prisons of [enemyFaction_name]. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nThe [asker_faction_pawnsPlural] know secrets about the [secretInfo] of [enemyFaction_name], so they will be hunted. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], recently rescued [lodgersCount] [asker_faction_pawnsPlural] from a crytosleep vault. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nThe [asker_faction_pawnsPlural] will be hunted by mechanoids. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==MechClusters)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], recently rescued [lodgersCount] [asker_faction_pawnsPlural] from a mechanoid hive's holding pen. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nThe mechs are tracking their former prisoners. As long as the [asker_faction_pawnsPlural] are with you, mechanoid combat clusters will drop near [map_definite] on a regular basis.\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>secretInfo->military capabilities</li>
+    <li>secretInfo->moral transgressions</li>
+    <li>secretInfo->weapons research</li>
+    <li>secretInfo->prison camps</li>
+    <li>secretInfo->[enemyFaction_leaderTitle]</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_nameFull], a [asker_royalTitleInCurrentFaction] of [asker_faction_name], is fleeing a troubling political situation and wants to hide out at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[asker_nameDef]'s enemies have hired [enemyFaction_name] to hunt [asker_objective]. They will attack repeatedly as long as [asker_nameDef] is present. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef]'s enemies provoked mechanoids into to hunting [asker_objective]. The mechs will attack repeatedly as long as [asker_nameDef] is present. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\n[asker_nameDef]'s enemies have somehow provoked mechanoids into hunting [asker_objective], so mech combat clusters will drop near [map_definite] repeatedly as long as [asker_nameDef] is present.</li>
+    <li>threatsInfo5(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_nameFull], a [asker_royalTitleInCurrentFaction] of [asker_faction_name], wants to stay at [map_definite] for [shuttleDelayTicks_duration] with [lodgersCountMinusOne] court [allyAllies]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[asker_nameDef] and [asker_possessive] [allyAllies] have been targeted for death and need a safe place to stay until they can purge their court. However, [asker_nameDef]'s enemies have hired [enemyFaction_name] to hunt [asker_objective]. They will attack repeatedly until [asker_nameDef] leaves. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef] and [asker_possessive] [allyAllies] have been targeted for death and need a safe place to stay until they can purge their court. However, [asker_nameDef]'s enemies have provoked [enemyFaction_name] into hunting [asker_objective]. Mechanoids will attack repeatedly until [asker_nameDef] leaves. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[asker_nameDef] and [asker_possessive] [allyAllies] have been targeted for death and need a safe place to stay until they can purge their court. However, [asker_nameDef]'s enemies have somehow provoked mechanoids into hunting [asker_objective], so mech combat clusters will regularly drop onto [map_definite] until [asker_nameDef] leaves.</li>
+    <li>threatsInfo6(generateThreats==false)-></li>
+    <li>allyAllies(lodgersCountMinusOne==1)->ally</li>
+    <li>allyAllies(lodgersCountMinusOne>=2)->allies</li>
+  -->
+  <Hospitality_Joiners.questDescriptionRules.rulesStrings>
+    <li>lodgersDef(lodgersCount==1)->[lodgers0_nameDef]</li>
+    <li>lodgersDef(lodgersCount>=2)->гостями</li>
+    <li>joinerEnding->Вы сможете управлять [lodgersDef] так же, как и своими поселенцами.[specialNeedsExplanation]</li>
+    <li>specialNeedsExplanation(asker_royalInCurrentFaction==True,priority=1)-> Вы должны будете удовлетворять все возможные особенные потребности ваших знатных гостей.</li>
+    <li>specialNeedsExplanation-></li>
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->[lodgers0_title] [lodgers0_nameFull] хочет, чтобы вы защищали [lodgers0_possessive] в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] [wrongAct]. Жаждущие мести [enemyFaction_pawnsPlural] будут приходить за [lodgers0_nameDef], пока [lodgers0_pronoun] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo1(generateThreats==false)-></li>
+    <li>wrongAct->оскорбляет [PersonalCharacteristic] лидера фракции [enemyFaction_name] [enemyFaction_leaderTitle] [enemyFaction_leader_nameDef]</li>
+    <li>wrongAct->крадёт скот у фракции [enemyFaction_name]</li>
+    <li>wrongAct->крадёт еду у фракции [enemyFaction_name]</li>
+    <li>wrongAct->крадёт религиозные артефакты у фракции [enemyFaction_name]</li>
+    <li>wrongAct->ломает саркофаги криптосна фракции [enemyFaction_name]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Группа из [lodgersCount] путешественников, хочет, чтобы вы приняли их в [map_definite] на [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo2]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЭти путешественники недавно были приглашены на важную церемонию фракции [enemyFaction_name], но заявились на неё пьяными и осквернили священный ритуал. [enemyFaction_name] будет отправлять своих налётчиков за ними. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsMultiHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\nЭти путешественники недавно [mechViolation_pl], и преследуются роем механоидов, базирующимся на орбите. Пока они здесь, в область [map_definite] будут регулярно десантироваться кластеры механоидов</li>
+    <li>threatsInfo2(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг [lodgers0_nameFull] заинтересован в изучении других культур. [asker_nameDef] хочет, чтобы вы приняли [lodgers0_nameDef] у себя в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друга ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef], недавно поймали за написанием жестоких оскорблений про [PersonalCharacteristic] лидера фракции [enemyFaction_leader_nameFull]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не уладит отношения с [enemyFaction_name]. [allLodgerInfo]\n\nТак как [enemyFaction_leader_nameDef] является врагом лидера фракции [enemyFaction_name] [enemyFaction_leaderTitle], [enemyFaction_leader_pronoun] отправил отряды [enemyFaction_pawnsPlural] чтобы выследить наглеца [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef], недавно [mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не успокоит рой механоидов. [allLodgerInfo]\n\nМеханоиды придут за головой [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг, ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ [lodgers0_title] по имени [lodgers0_nameDef], недавно [mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration]. Кластеры механоидов будут десантироваться, пока [lodgers0_nameDef] присутствует в поселении. [allLodgerInfo][threatsInfo1] [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из вражеской тюрьмы. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из тюрем [enemyFaction_name]. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] знают секрутную информацию о [secretInfo] фракции [enemyFaction_name], поэтому за ними будут охотиться. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из хранилища крипто-сна. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] будут преследоваться механоидами. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount]] организованного механоидами загона для пленных. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nМеханоиды отслеживают перемещение бывших пленных.  Пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>secretInfo->военных возможностях</li>
+    <li>secretInfo->«грехах»</li>
+    <li>secretInfo->военных разработках</li>
+    <li>secretInfo->лагерях заключённых</li>
+    <li>secretInfo->[enemyFaction_leaderTitle]</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_nameFull], [asker_royalTitleInCurrentFaction] из фракции [asker_faction_name], спасается бегством после настораживающего политического инцидента и хочет укрыться в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nВраги [asker_nameDef] наняли [enemyFaction_name], чтобы выследить [asker_possessive]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive]. Механоиды будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\nВраги [asker_nameDef] спровоцировали механоидов напасть на н[asker_possessive], поэтому, пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].</li>
+    <li>threatsInfo5(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_royalTitleInCurrentFaction] [asker_nameFull] из фракции [asker_faction_name], хочет погостить в [map_definite] в течение [shuttleDelayTicks_duration] с [lodgersCountMinusOne] [allyAllies] из [asker_possessive] двора. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] наняли [enemyFaction_name], чтобы охотиться за [asker_objective]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive]. Механоиды будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению враги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive], поэтому, пока [asker_nameDef] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].</li>
+    <li>threatsInfo6(generateThreats==false)-></li>
+    <li>allyAllies(lodgersCountMinusOne==1)->союз</li>
+    <li>allyAllies(lodgersCountMinusOne>=2)->союзники</li>
+  </Hospitality_Joiners.questDescriptionRules.rulesStrings>
+  <!-- EN:
+    <li>questName->shelter for [lodgerIndef]</li>
+    <li>questName->hospitality for [lodgerIndef]</li>
+    <li>questName->hosting [lodgerIndef]</li>
+    <li>questName->[lodgerIndef] needing help</li>
+    <li>questName(generateThreats==true,priority=1)->protecting [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->safeguarding [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->security for [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] under threat</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] in danger</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] with enemies</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] in the crosshairs</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount==1)->a [lodgers0_title]</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount>=2)->travelers</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->a [lodgers0_title]</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->a friend</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->an ally</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount>=2)->friends</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount>=2)->allies</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1,p=3)->a [asker_royalTitleInCurrentFaction]</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_label]</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->a royal</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->a noble</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->an aristocrat</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->royals</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->nobles</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->aristocrats</li>
+  -->
+  <Hospitality_Joiners.questNameRules.rulesStrings>
+    <li>questName->убежише для [lodgerIndef]</li>
+    <li>questName->приют для [lodgerIndef]</li>
+    <li>questName->принять в гости [lodgerIndef]</li>
+    <li>questName->[lodgerIndef] needing help</li>
+    <li>questName(generateThreats==true,priority=1)->protecting [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->safeguarding [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->security for [lodgerIndef]</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] под угрозой</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] в опасности</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] с врагами на хвосте</li>
+    <li>questName(generateThreats==true,priority=1)->[lodgerIndef] под прицелом</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount==1)->[lodgers0_title]</li>
+    <li>lodgerIndef(askerIsNull==true,lodgersCount>=2)->путешественники</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->[lodgers0_title]</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->друг</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount==1)->союзник</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount>=2)->друзья</li>
+    <li>lodgerIndef(asker_factionLeader==True,lodgersCount>=2)->союзники</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1,p=3)->[asker_royalTitleInCurrentFaction]</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_label]</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->дворянин</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->знатный человек</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount==1)->аристократ</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->дворяне</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->знатные люди</li>
+    <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->аристократы</li>
+  </Hospitality_Joiners.questNameRules.rulesStrings>
+  <!-- EN: Guest unhappy: {SUBJECT_definite} -->
+  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>гость несчастлив: {SUBJECT_definite}</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>
+  <!-- EN: {SUBJECT_definite}, who you were charged to protect and keep happy, has been below the minimum mood of [lodgersMoodThreshold_percent] too long.\n\n[remainingWillNowLeave] -->
+  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>{SUBJECT_definite}, гость, которого вы должны были защищать и делать счастливым, пробыл в настроении ниже минимального [lodgersMoodThreshold_percent] слишком долго.\n\n[remainingWillNowLeave]</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>
+  
+</LanguageData>

--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Joiners.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Joiners.xml
@@ -6,8 +6,12 @@
     <li>lodgersLabelPlural->guests</li>
   -->
   <Hospitality_Joiners.questDescriptionAndNameRules.rulesStrings>
-    <li>lodgersLabel->задание</li>
-    <li>lodgersLabelPlural->задания</li>
+    <li>lodgersLabel(lodgers0_gender==Male)->гость</li>
+    <li>lodgersLabel(lodgers0_gender==Female)->гостья</li>
+    <li>lodgersLabelPlural->гости</li>
+    <li>lodgersLabel_gen(lodgers0_gender==Male)->гостя</li>
+    <li>lodgersLabel_gen(lodgers0_gender==Female)->гостью</li>
+    <li>lodgersLabelPlural_gen->гостей</li>
   </Hospitality_Joiners.questDescriptionAndNameRules.rulesStrings>
   <!-- EN:
     <li>lodgersDef(lodgersCount==1)->[lodgers0_nameDef]</li>
@@ -62,46 +66,62 @@
     <li>joinerEnding->Вы сможете управлять [lodgersDef] так же, как и своими поселенцами.[specialNeedsExplanation]</li>
     <li>specialNeedsExplanation(asker_royalInCurrentFaction==True,priority=1)-> Вы должны будете удовлетворять все возможные особенные потребности ваших знатных гостей.</li>
     <li>specialNeedsExplanation-></li>
-    <li>questDescription(askerIsNull==true,lodgersCount==1)->[lodgers0_title] [lodgers0_nameFull] хочет, чтобы вы защищали [lodgers0_possessive] в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] [wrongAct]. Жаждущие мести [enemyFaction_pawnsPlural] будут приходить за [lodgers0_nameDef], пока [lodgers0_pronoun] с вами. [enemyGroupsParagraph]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->[lodgers0_title] [lodgers0_nameFull] хочет, чтобы вы [shuttleDelayTicks_duration] защищали [lodgers0_possessive] в [map_definite]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] [lodgers0_wasCaught] на [wrongAct]. Жаждущие мести [enemyFaction_pawnsPlural] будут приходить за [lodgers0_him], пока [lodgers0_pronoun] с вами. [enemyGroupsParagraph]</li>
+    <li>lodgers0_wasCaught(lodgers0_gender==Male)->был пойман</li>
+    <li>lodgers0_wasCaught(lodgers0_gender==Female)->была поймана</li>
+    <li>lodgers0_him(lodgers0_gender==Male)->ним</li>
+    <li>lodgers0_him(lodgers0_gender==Female)->ней</li>
     <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
     <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
     <li>threatsInfo1(generateThreats==false)-></li>
-    <li>wrongAct->оскорбляет [PersonalCharacteristic] лидера фракции [enemyFaction_name] [enemyFaction_leaderTitle] [enemyFaction_leader_nameDef]</li>
-    <li>wrongAct->крадёт скот у фракции [enemyFaction_name]</li>
-    <li>wrongAct->крадёт еду у фракции [enemyFaction_name]</li>
-    <li>wrongAct->крадёт религиозные артефакты у фракции [enemyFaction_name]</li>
-    <li>wrongAct->ломает саркофаги криптосна фракции [enemyFaction_name]</li>
-    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Группа из [lodgersCount] путешественников, хочет, чтобы вы приняли их в [map_definite] на [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo2]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЭти путешественники недавно были приглашены на важную церемонию фракции [enemyFaction_name], но заявились на неё пьяными и осквернили священный ритуал. [enemyFaction_name] будет отправлять своих налётчиков за ними. [enemyGroupsParagraph]</li>
+    <li>wrongAct->оскорблении [PersonalCharacteristic] лидера фракции [enemyFaction_name], [enemyFaction_leaderTitle] [enemyFaction_leader_nameDef]</li>
+    <li>wrongAct->краже скота у фракции [enemyFaction_name]</li>
+    <li>wrongAct->краже еды у фракции [enemyFaction_name]</li>
+    <li>wrongAct->краже религиозных артефактов у фракции [enemyFaction_name]</li>
+    <li>wrongAct->порче саркофагов криптосна фракции [enemyFaction_name]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Группа из [lodgersCount] путешественников хочет, чтобы вы приняли их в [map_definite] на [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo2]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЭти путешественники недавно были приглашены на важную церемонию фракции [enemyFaction_name], но заявились на неё пьяными и осквернили священный ритуал. Фракция [enemyFaction_name] будет отправлять своих налётчиков за ними. [enemyGroupsParagraph]</li>
     <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsMultiHuman] [enemyGroupsParagraph]</li>
-    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\nЭти путешественники недавно [mechViolation_pl], и преследуются роем механоидов, базирующимся на орбите. Пока они здесь, в область [map_definite] будут регулярно десантироваться кластеры механоидов</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\nЭти путешественники недавно [mechViolation_plural], и преследуются роем механоидов, базирующимся на орбите. Пока они здесь, на [map_definite] будут регулярно десантироваться кластеры механоидов.</li>
     <li>threatsInfo2(generateThreats==false)-></li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг [lodgers0_nameFull] заинтересован в изучении других культур. [asker_nameDef] хочет, чтобы вы приняли [lodgers0_nameDef] у себя в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друга ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef], недавно поймали за написанием жестоких оскорблений про [PersonalCharacteristic] лидера фракции [enemyFaction_leader_nameFull]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не уладит отношения с [enemyFaction_name]. [allLodgerInfo]\n\nТак как [enemyFaction_leader_nameDef] является врагом лидера фракции [enemyFaction_name] [enemyFaction_leaderTitle], [enemyFaction_leader_pronoun] отправил отряды [enemyFaction_pawnsPlural] чтобы выследить наглеца [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef], недавно [mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не успокоит рой механоидов. [allLodgerInfo]\n\nМеханоиды придут за головой [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] друг, ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ [lodgers0_title] по имени [lodgers0_nameDef], недавно [mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] в течение [shuttleDelayTicks_duration]. Кластеры механоидов будут десантироваться, пока [lodgers0_nameDef] присутствует в поселении. [allLodgerInfo][threatsInfo1] [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из вражеской тюрьмы. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из тюрем [enemyFaction_name]. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] знают секрутную информацию о [secretInfo] фракции [enemyFaction_name], поэтому за ними будут охотиться. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount] [asker_faction_pawnsPlural] из хранилища крипто-сна. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] будут преследоваться механоидами. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно вызволил [lodgersCount]] организованного механоидами загона для пленных. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] в течение [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nМеханоиды отслеживают перемещение бывших пленных.  Пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] [lodgers0_friend], [lodgers0_nameFull], [lodgers0_interested] в изучении других культур. [asker_nameDef] хочет, чтобы вы приняли [lodgers0_possessive] у себя в [map_definite] на [shuttleDelayTicks_duration]. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name], просит об одолжении. [asker_possessive] [lodgers0_friend_gen] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef] недавно поймали за написанием жестоких оскорблений про [PersonalCharacteristic] лидера фракции, [enemyFaction_leader_nameFull]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] [shuttleDelayTicks_duration], пока [asker_pronoun] не уладит отношения с фракцией [enemyFaction_name]. [allLodgerInfo]\n\nТак как [enemyFaction_leader_nameDef] — [enemyFaction_leaderTitle] фракции [enemyFaction_name], [enemyFaction_leader_pronoun] [enemyFaction_leader_sent] отряды [enemyFaction_pawnsPlural], чтобы выследить наглеца. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>enemyFaction_leader_sent(enemyFaction_leader==Male)->отправил</li>
+    <li>enemyFaction_leader_sent(enemyFaction_leader==Female)->отправила</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name], просит об одолжении. [asker_possessive] [lodgers0_friend] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef] недавно [lodgers0_mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] [shuttleDelayTicks_duration], пока [asker_pronoun] не успокоит рой механоидов. [allLodgerInfo]\n\nМеханоиды придут за головой [lodgers0_nameDef]. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] просит об одолжении. [asker_possessive] [lodgers0_friend], [lodgers0_title] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameDef], недавно [lodgers0_mechViolation]. [asker_nameDef] просит вас охранять [lodgers0_nameDef] [shuttleDelayTicks_duration]. Кластеры механоидов будут десантироваться, пока [lodgers0_nameDef] присутствует в поселении. [allLodgerInfo][threatsInfo1] [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>lodgers0_friend(lodgers0_gender==Male)->друг</li>
+    <li>lodgers0_friend(lodgers0_gender==Female)->подруга</li>
+    <li>lodgers0_friend_gen(lodgers0_gender==Male)->друга</li>
+    <li>lodgers0_friend_gen(lodgers0_gender==Female)->подругу</li>
+    <li>lodgers0_interested(lodgers0_gender==Male)->заинтересован</li>
+    <li>lodgers0_interested(lodgers0_gender==Female)->заинтересована</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==false)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно [asker_freed] [lodgersCount] [asker_faction_pawnsPlural] из вражеской тюрьмы. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно [asker_freed] [lodgersCount] [asker_faction_pawnsPlural] из тюрем фракции [enemyFaction_name]. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] знают секретную информацию о [secretInfo] фракции [enemyFaction_name], поэтому за ними будут охотиться. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно [asker_freed] [lodgersCount] [asker_faction_pawnsPlural] из хранилища криптосна. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\n[asker_faction_pawnsPlural] будут преследоваться механоидами. [enemyGroupsParagraph]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2,generateThreats==true,allowedThreats==MechClusters)->[asker_faction_leaderTitle] [asker_nameFull], глава фракции [asker_faction_name], недавно [asker_freed] [lodgersCount] узников из организованного механоидами загона для пленных. [asker_nameDef] хочет, чтобы вы укрывали их в [map_definite] [shuttleDelayTicks_duration], пока [asker_pronoun] не сможет отправить челнок, чтобы их забрать. [allLodgerInfo]\n\nМеханоиды отслеживают перемещение бывших пленных. Пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться на [map_definite].\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>asker_freed(asker_gender==Male)->вызволил</li>
+    <li>asker_freed(asker_gender==Female)->вызволила</li>
     <li>secretInfo->военных возможностях</li>
     <li>secretInfo->«грехах»</li>
     <li>secretInfo->военных разработках</li>
     <li>secretInfo->лагерях заключённых</li>
     <li>secretInfo->[enemyFaction_leaderTitle]</li>
-    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_nameFull], [asker_royalTitleInCurrentFaction] из фракции [asker_faction_name], спасается бегством после настораживающего политического инцидента и хочет укрыться в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nВраги [asker_nameDef] наняли [enemyFaction_name], чтобы выследить [asker_possessive]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
-    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive]. Механоиды будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
-    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\nВраги [asker_nameDef] спровоцировали механоидов напасть на н[asker_possessive], поэтому, пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_nameFull], [asker_royalTitleInCurrentFaction] из фракции [asker_faction_name], спасается бегством после тревожного политического инцидента и хочет укрыться в [map_definite] на [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nВраги [asker_nameDef] наняли фракцию [enemyFaction_name], чтобы выследить [asker_possessive]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] натравили на н[asker_possessive] механоидов. Они будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\nВраги [asker_nameDef] натравили на н[asker_possessive] механоидов, поэтому, пока [asker_faction_pawnsPlural] с вами, кластеры механоидов будут регулярно десантироваться на [map_definite].</li>
     <li>threatsInfo5(generateThreats==false)-></li>
-    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_royalTitleInCurrentFaction] [asker_nameFull] из фракции [asker_faction_name], хочет погостить в [map_definite] в течение [shuttleDelayTicks_duration] с [lodgersCountMinusOne] [allyAllies] из [asker_possessive] двора. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding] [joinerEnding]</li>
-    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] наняли [enemyFaction_name], чтобы охотиться за [asker_objective]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
-    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive]. Механоиды будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
-    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и нуждаются в безопасном месте, на время проведения чисток среди своих придворных. К сожалению враги [asker_nameDef] спровоцировали механоидов охотиться на н[asker_possessive], поэтому, пока [asker_nameDef] с вами, кластеры механоидов будут регулярно десантироваться в область [map_definite].</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_nameFull], [asker_royalTitleInCurrentFaction] из фракции [asker_faction_name], и ещё ^Number( [lodgersCountMinusOne] | '# человек' | '# человека' | '# людей')^ из [asker_possessive] двора хотят [shuttleDelayTicks_duration] погостить в [map_definite]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding] [joinerEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и ищут безопасное место на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] наняли фракцию [enemyFaction_name], чтобы охотиться за [asker_him]. Они будут регулярно нападать, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и ищут безопасное место на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] натравили на н[asker_possessive] механоидов. Они будут атаковать вас, пока [asker_nameDef] с вами. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[asker_nameDef] и [asker_possessive] [allyAllies] стали целью смертельного заговора и ищут безопасное место на время проведения чисток среди своих придворных. К сожалению, враги [asker_nameDef] натравили на н[asker_possessive] механоидов, поэтому, пока [asker_nameDef] с вами, кластеры механоидов будут регулярно десантироваться на [map_definite].</li>
     <li>threatsInfo6(generateThreats==false)-></li>
-    <li>allyAllies(lodgersCountMinusOne==1)->союз</li>
-    <li>allyAllies(lodgersCountMinusOne>=2)->союзники</li>
+    <li>asker_him(asker_gender==Male)->ним</li>
+    <li>asker_him(asker_gender==Female)->ней</li>
+    <li>allyAllies(lodgersCountMinusOne==1)->человек</li>
+    <li>allyAllies(lodgersCountMinusOne>=2)->люди</li>
   </Hospitality_Joiners.questDescriptionRules.rulesStrings>
   <!-- EN:
     <li>questName->shelter for [lodgerIndef]</li>
@@ -134,13 +154,12 @@
     <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->aristocrats</li>
   -->
   <Hospitality_Joiners.questNameRules.rulesStrings>
-    <li>questName->убежише для [lodgerIndef]</li>
-    <li>questName->приют для [lodgerIndef]</li>
-    <li>questName->принять в гости [lodgerIndef]</li>
-    <li>questName->[lodgerIndef] needing help</li>
-    <li>questName(generateThreats==true,priority=1)->protecting [lodgerIndef]</li>
-    <li>questName(generateThreats==true,priority=1)->safeguarding [lodgerIndef]</li>
-    <li>questName(generateThreats==true,priority=1)->security for [lodgerIndef]</li>
+    <li>questName->убежище для [lodgerIndef_gen]</li>
+    <li>questName->приют для [lodgerIndef_gen]</li>
+    <li>questName->спасение [lodgerIndef_gen]</li>
+    <li>questName(generateThreats==true,priority=1)->защищая [lodgerIndef_gen]</li>
+    <li>questName(generateThreats==true,priority=1)->охраняя [lodgerIndef_gen]</li>
+    <li>questName(generateThreats==true,priority=1)->безопасность для [lodgerIndef_gen]</li>
     <li>questName(generateThreats==true,priority=1)->[lodgerIndef] под угрозой</li>
     <li>questName(generateThreats==true,priority=1)->[lodgerIndef] в опасности</li>
     <li>questName(generateThreats==true,priority=1)->[lodgerIndef] с врагами на хвосте</li>
@@ -162,10 +181,24 @@
     <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->дворяне</li>
     <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->знатные люди</li>
     <li>lodgerIndef(asker_royalInCurrentFaction==True,lodgersCount>=2)->аристократы</li>
+    <li>lodgerIndef_gen(askerIsNull==true,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef_gen(askerIsNull==true,lodgersCount>=2)->путешественников</li>
+    <li>lodgerIndef_gen(asker_factionLeader==True,lodgersCount==1)->[lodgers0_label]</li>
+    <li>lodgerIndef_gen(asker_factionLeader==True,lodgersCount==1)->друга</li>
+    <li>lodgerIndef_gen(asker_factionLeader==True,lodgersCount==1)->союзника</li>
+    <li>lodgerIndef_gen(asker_factionLeader==True,lodgersCount>=2)->друзей</li>
+    <li>lodgerIndef_gen(asker_factionLeader==True,lodgersCount>=2)->союзников</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_label]</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount==1)->дворянина</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount==1)->знатного человека</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount==1)->аристократа</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount>=2)->дворян</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount>=2)->знатных людей</li>
+    <li>lodgerIndef_gen(asker_royalInCurrentFaction==True,lodgersCount>=2)->аристократов</li>
   </Hospitality_Joiners.questNameRules.rulesStrings>
   <!-- EN: Guest unhappy: {SUBJECT_definite} -->
-  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>гость несчастлив: {SUBJECT_definite}</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>
+  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>гость недоволен: {SUBJECT_definite}</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.label.slateRef>
   <!-- EN: {SUBJECT_definite}, who you were charged to protect and keep happy, has been below the minimum mood of [lodgersMoodThreshold_percent] too long.\n\n[remainingWillNowLeave] -->
-  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>{SUBJECT_definite}, гость, которого вы должны были защищать и делать счастливым, пробыл в настроении ниже минимального [lodgersMoodThreshold_percent] слишком долго.\n\n[remainingWillNowLeave]</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>
+  <Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>{SUBJECT_definite}, гость, которого вы должны были защищать и опекать, пробыл в настроении ниже минимальных [lodgersMoodThreshold_percent] слишком долго.\n\n[remainingWillNowLeave]</Hospitality_Joiners.root.nodes.IsTrue-0.node.nodes.MoodBelow.node.nodes.Letter.text.slateRef>
   
 </LanguageData>

--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Prisoners.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Prisoners.xml
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+  
+  <!-- EN:
+    <li>lodgersLabel->prisoner</li>
+    <li>lodgersLabelPlural->prisoners</li>
+  -->
+  <Hospitality_Prisoners.questDescriptionAndNameRules.rulesStrings>
+    <li>lodgersLabel->заключенный</li>
+    <li>lodgersLabelPlural->заключенные</li>
+  </Hospitality_Prisoners.questDescriptionAndNameRules.rulesStrings>
+  <!-- EN:
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->An orbiting ship captain wants you to guard a prisoner named [lodgers0_nameFull] at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] recently spat on the most loved child of [enemyFaction_leader_nameFull], [enemyFaction_leaderTitle] of [enemyFaction_name]. [enemyFaction_leader_nameDef] will send [enemyFaction_pawnsPlural] to seek revenge on any who would protect [lodgers0_objective]. [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo1(generateThreats==false)-></li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->An orbiting ship captain wants you to guard [lodgersCount] prisoners at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo2]\n\n[commonDescEnding]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nThe prisoners committed a string of murders against the [enemyFaction_pawnsPlural] of [enemyFaction_name], and their victims' families will send raids to seek revenge. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nThe prisoners recently [mechViolation], and have been targeted by a mechanoid hive. It will send mechs to attack as long as they are present. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo2(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], wants you to stash a special prisoner for [asker_objective]. The prisoner, a [lodgers0_age]-year-old [lodgers0_title] named [lodgers0_nameFull], knows embarrassing information about [asker_nameDef]'s [PersonalCharacteristic], and [asker_nameDef] doesn't want [lodgers0_objective] to be freed. You only need to keep the prisoner for [shuttleDelayTicks_duration] until the scandal passes. [allLodgerInfo][threatsInfo3]\n\n[commonDescEnding]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nUnfortunately, [enemyFaction_name] wants to spread the shameful story and is sending raids to break [lodgers0_nameDef] out of jail. [enemyGroupsParagraph]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo3(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2)->[asker_nameFull], [asker_faction_leaderTitle] of [asker_faction_name], has captured [lodgersCount] prisoners from an enemy faction. With no place to store them, [asker_nameDef] wants you to watch over them for [shuttleDelayTicks_duration], until [asker_possessive] prison is ready.[allLodgerInfo][threatsInfo4]\n\n[commonDescEnding]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nThe prisoners have a paid rescue contract with [enemyFaction_name], so they will send [enemyFaction_pawnsPlural] after you. [enemyGroupsParagraph]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[asker_nameDef]'s enemies have some provoked a mechanoid hive into hunting the prisoners, so it will send mechanoid attack groups. [enemyGroupsParagraph]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo4(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_nameFull], a [asker_royalTitleInCurrentFaction] of [asker_faction_name] has been caught in bed with the wrong person. [asker_pronoun] imprisoned the inappropriate lover in a show of rejection. Now [asker_pronoun] wants you to keep the prisoner [lodgers0_nameFull] caged until the scandal blows over in [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nUnfortunately, [asker_nameDef]'s court rivals are paying [enemyFaction_name] to try to break the lover out and bring the story to light. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nUnfortunately, [asker_nameDef]'s court rivals have provoked mechanoids attacks from [enemyFaction_name] to try to break the lover out and bring the story to light. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo5(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_nameFull], a [asker_royalTitleInCurrentFaction] of [asker_faction_name], seeks your help. [asker_nameDef]'s royal archaeologists recently extracted [lodgersCount] prisoners from an ancient cryptosleep vault, and intend to question them. To keep the prisoners secret from court rivals, [asker_nameDef] wants you to hold them for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nUnfortunately, [enemyFaction_pawnsPlural] from [enemyFaction_name] revered the vault that the prisoners were extracted from. They'll send raids to seek revenge on anyone who holds them. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nUnfortunately, [enemyFaction_pawnsPlural] from [enemyFaction_name] were guarding the vault that the prisoners were extracted from. They'll send mechanoids to hunt down the lost sleepers. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo6(generateThreats==false)-></li>
+  -->
+  <Hospitality_Prisoners.questDescriptionRules.rulesStrings>
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->Капитан корабля, расположившегося на орбите, хочет, чтобы вы разместили заключённого, по имени [lodgers0_nameFull] в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] недавно плюнул на самого любимого ребёнка главы фракции [enemyFaction_name] [enemyFaction_leaderTitle] [enemyFaction_leader_nameFull]. [enemyFaction_leader_nameDef] отправит [enemyFaction_pawnsPlural], чтобы отомстить любому, кто будет защищать [lodgers0_objective]. [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo1(generateThreats==false)-></li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Капитан корабля, расположившегося на орбите, хочет, чтобы вы разместили заключённых в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЗаключённые недавно совершили серию убийств [enemyFaction_pawnsPlural] из фракции [enemyFaction_name], и семьи погибших будут организовывать налёты, пока они находятся у вас. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nЭти заключённые недавно [mechViolation_pl], и преследуются роем механоидов. Пока они здесь, механоиды будут совершить регулярные налёты. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo2(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] хочет, чтобы вы разместили у себе особенного заключённого для н[asker_possessive]. Заключённый, [lodgers0_title] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameFull], располагает позорящей честь и достоинство информацией про [PersonalCharacteristic] [asker_nameDef], и [asker_pronoun] не хочет, [lodgers0_objective] на свободе. Вам нужно держать заключённого у себя только в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo3]\n\n[commonDescEnding]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, фракция [enemyFaction_name] хочет, чтобы история распространилась и будет отправлять налёты, чтобы вызволить [lodgers0_nameDef] из тюрьмы. [enemyGroupsParagraph]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo3(generateThreats==false)-></li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] захватывает [lodgersCount] заключённых из вражеской фракции. Так как их некуда, разместить, [asker_nameDef] хочет, чтобы вы присматривали за ними в течение [shuttleDelayTicks_duration], пока [asker_possessive] тюрьма не будет готова.[allLodgerInfo][threatsInfo4]\n\n[commonDescEnding]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЗаключённые оформили контракт по спасению с [enemyFaction_name], поэтому они будут отправлять [enemyFaction_pawnsPlural] в ваше поселение. [enemyGroupsParagraph]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] спровоцировали рой механоидов охотиться на заключённых, поэтому они будут на вас регулярно нападать. [enemyGroupsParagraph]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo4(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] попадается в постели с неправильным человеком. [asker_pronoun] заключила под стражу нежелательного любовника в знак его отвержения. Теперь [asker_pronoun] хочет, чтобы вы держали [lodgers0_nameFull] у себя в заключении в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору заплатили фракции [enemyFaction_name] чтобы попытаться вызволить заключённого и пролить свет на историю. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору спровоцировали механоидов, чтобы те вызволили заключённого и пролили свет на историю. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
+    <li>threatsInfo5(generateThreats==false)-></li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_royalTitleInCurrentFaction] [asker_nameFull] из фракции [asker_faction_name], нуждается в вашей помощи. [asker_possessive] придворные археологи недавно извлекли [lodgersCount] заключённых из древнего хранилища крипто-сна, и собираются допросить их. Чтобы сохранить заключённых, как тайну от соперников по двору, [asker_nameDef] хочет, чтобы вы разместили их у себя в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, [enemyFaction_pawnsPlural] из фракции [enemyFaction_name] почитали хранилище, откуда были извлечены заключённые. Они будут отправлять налётчиков любому, кто будет удерживать у себя этих заключённых. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nК сожалению, [enemyFaction_pawnsPlural] из фракции [enemyFaction_name] охраняли хранилище, откуда были извлечены заключённые. Они будут отправлять отряды механоидов, чтобы вернуть обратно утерянных узников. [enemyGroupsParagraph]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
+    <li>threatsInfo6(generateThreats==false)-></li>
+  </Hospitality_Prisoners.questDescriptionRules.rulesStrings>
+  <!-- EN:
+    <li>questName->Guarding for [asker_nameDef]</li>
+    <li>questName(lodgersCount==1)->guarding [lodgers0_nameDef]</li>
+    <li>questName(lodgersCount==1)->prisoner [lodgers0_nameDef]</li>
+    <li>questName(lodgersCount==1)->the [adjAny] prisoner</li>
+    <li>questName(lodgersCount==1)->one [adjAny] prisoner</li>
+    <li>questName(lodgersCount>=2)->warden for hire</li>
+    <li>questName(lodgersCount>=2)->prison warden</li>
+    <li>questName(lodgersCount>=2)->contract prison</li>
+    <li>questName(lodgersCount>=2)->the wanted prisoners</li>
+    <li>questName(lodgersCount>=2)->the [adjAny] prisoners</li>
+    <li>questName(lodgersCount>=2)->[asker_nameDef]'s prisoners</li>
+    <li>adjAny->[AdjectiveBadass]</li>
+    <li>adjAny->[AdjectiveAngsty]</li>
+    <li>adjAny->[AdjectiveFriendly]</li>
+  -->
+  <Hospitality_Prisoners.questNameRules.rulesStrings>
+    <li>questName->размещение заключённых для [asker_nameDef]</li>
+    <li>questName(lodgersCount==1)->охранять [lodgers0_nameDef]</li>
+    <li>questName(lodgersCount==1)->заключённый [lodgers0_nameDef]</li>
+    <li>questName(lodgersCount==1)->[adjAny] заключённый</li>
+    <li>questName(lodgersCount==1)->[adjAny] заключённый</li>
+    <li>questName(lodgersCount>=2)->наёмный надзиратель</li>
+    <li>questName(lodgersCount>=2)->тюремный надзиратель</li>
+    <li>questName(lodgersCount>=2)->контрактная тюрьма</li>
+    <li>questName(lodgersCount>=2)->разыскиваемые заключённые</li>
+    <li>questName(lodgersCount>=2)->[adjAny] заключённые</li>
+    <li>questName(lodgersCount>=2)->[asker_nameDef]: заключённые</li>
+    <li>adjAny->[AdjectiveBadass]</li>
+    <li>adjAny->[AdjectiveAngsty]</li>
+    <li>adjAny->[AdjectiveFriendly]</li>
+  </Hospitality_Prisoners.questNameRules.rulesStrings>
+  
+</LanguageData>

--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Prisoners.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Root_Prisoners.xml
@@ -6,8 +6,12 @@
     <li>lodgersLabelPlural->prisoners</li>
   -->
   <Hospitality_Prisoners.questDescriptionAndNameRules.rulesStrings>
-    <li>lodgersLabel->заключенный</li>
+    <li>lodgersLabel(lodgers0_gender==Male)->заключенный</li>
+    <li>lodgersLabel(lodgers0_gender==Female)->заключенная</li>
     <li>lodgersLabelPlural->заключенные</li>
+    <li>lodgersLabel_gen(lodgers0_gender==Male)->заключенного</li>
+    <li>lodgersLabel_gen(lodgers0_gender==Female)->заключенную</li>
+    <li>lodgersLabelPlural_gen->заключенных</li>
   </Hospitality_Prisoners.questDescriptionAndNameRules.rulesStrings>
   <!-- EN:
     <li>questDescription(askerIsNull==true,lodgersCount==1)->An orbiting ship captain wants you to guard a prisoner named [lodgers0_nameFull] at [map_definite] for [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
@@ -42,36 +46,50 @@
     <li>threatsInfo6(generateThreats==false)-></li>
   -->
   <Hospitality_Prisoners.questDescriptionRules.rulesStrings>
-    <li>questDescription(askerIsNull==true,lodgersCount==1)->Капитан корабля, расположившегося на орбите, хочет, чтобы вы разместили заключённого, по имени [lodgers0_nameFull] в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
-    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] недавно плюнул на самого любимого ребёнка главы фракции [enemyFaction_name] [enemyFaction_leaderTitle] [enemyFaction_leader_nameFull]. [enemyFaction_leader_nameDef] отправит [enemyFaction_pawnsPlural], чтобы отомстить любому, кто будет защищать [lodgers0_objective]. [enemyGroupsParagraph]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount==1)->Капитан корабля, находящегося на орбите, хочет, чтобы вы разместили в [map_definite] [lodgers0_prisoner_gen] по имени [lodgers0_nameFull] на срок [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
+    <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\n[lodgers0_nameDef] недавно проявил пренебрежение к самому любимому ребёнку главы фракции [enemyFaction_name], [enemyFaction_leaderTitle] [enemyFaction_leader_nameFull]. [enemyFaction_leader_nameDef] отправит [enemyFaction_pawnsPlural], чтобы отомстить любому, кто будет защищать [lodgers0_possessive]. [enemyGroupsParagraph]</li>
     <li>threatsInfo1(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
     <li>threatsInfo1(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
     <li>threatsInfo1(generateThreats==false)-></li>
-    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Капитан корабля, расположившегося на орбите, хочет, чтобы вы разместили заключённых в [map_definite] в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
+    <li>questDescription(askerIsNull==true,lodgersCount>=2)->Капитан корабля, находящегося на орбите, хочет, чтобы вы разместили заключённых в [map_definite] на срок [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo1]\n\n[commonDescEnding]</li>
     <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЗаключённые недавно совершили серию убийств [enemyFaction_pawnsPlural] из фракции [enemyFaction_name], и семьи погибших будут организовывать налёты, пока они находятся у вас. [enemyGroupsParagraph]</li>
-    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nЭти заключённые недавно [mechViolation_pl], и преследуются роем механоидов. Пока они здесь, механоиды будут совершить регулярные налёты. [enemyGroupsParagraph]</li>
+    <li>threatsInfo2(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nЭти заключённые недавно [mechViolation_plural], и преследуются роем механоидов. Пока они здесь, механоиды будут совершать регулярные налёты. [enemyGroupsParagraph]</li>
     <li>threatsInfo2(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
     <li>threatsInfo2(generateThreats==false)-></li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] хочет, чтобы вы разместили у себе особенного заключённого для н[asker_possessive]. Заключённый, [lodgers0_title] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameFull], располагает позорящей честь и достоинство информацией про [PersonalCharacteristic] [asker_nameDef], и [asker_pronoun] не хочет, [lodgers0_objective] на свободе. Вам нужно держать заключённого у себя только в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo3]\n\n[commonDescEnding]</li>
-    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, фракция [enemyFaction_name] хочет, чтобы история распространилась и будет отправлять налёты, чтобы вызволить [lodgers0_nameDef] из тюрьмы. [enemyGroupsParagraph]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] хочет, чтобы вы разместили у себя важного для н[asker_possessive] заключённого. [lodgers0_prisoner], [lodgers0_title] ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^ по имени [lodgers0_nameFull], располагает позорящей честь и достоинство информацией про [PersonalCharacteristic] [asker_nameDef], и [asker_pronoun] не хочет, чтобы [lodgers0_pronoun] [lodgers0_become] на свободе. Вам нужно держать [lodgers0_prisoner_gen] у себя в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo3]\n\n[commonDescEnding]</li>
+    <li>lodgers0_become(lodgers0_gender==Male)->оказался</li>
+    <li>lodgers0_become(lodgers0_gender==Female)->оказалась</li>
+    <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, фракция [enemyFaction_name] хочет придать истории огласку, и будет отправлять налёты, чтобы вызволить [lodgers0_nameDef] из тюрьмы. [enemyGroupsParagraph]</li>
     <li>threatsInfo3(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\n[threatsInfoMechRaidsSingleHuman] [enemyGroupsParagraph]</li>
     <li>threatsInfo3(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
     <li>threatsInfo3(generateThreats==false)-></li>
-    <li>questDescription(asker_factionLeader==True,lodgersCount>=2)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] захватывает [lodgersCount] заключённых из вражеской фракции. Так как их некуда, разместить, [asker_nameDef] хочет, чтобы вы присматривали за ними в течение [shuttleDelayTicks_duration], пока [asker_possessive] тюрьма не будет готова.[allLodgerInfo][threatsInfo4]\n\n[commonDescEnding]</li>
-    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЗаключённые оформили контракт по спасению с [enemyFaction_name], поэтому они будут отправлять [enemyFaction_pawnsPlural] в ваше поселение. [enemyGroupsParagraph]</li>
-    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] спровоцировали рой механоидов охотиться на заключённых, поэтому они будут на вас регулярно нападать. [enemyGroupsParagraph]</li>
+    <li>questDescription(asker_factionLeader==True,lodgersCount>=2)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name], [asker_captured] [lodgersCount] пленных из вражеской фракции. Так как их некуда разместить, [asker_nameDef] хочет, чтобы вы присматривали за ними в течение [shuttleDelayTicks_duration], пока [asker_possessive] тюрьма не будет готова.[allLodgerInfo][threatsInfo4]\n\n[commonDescEnding]</li>
+    <li>asker_captured(asker_gender==Male)->захватил</li>
+    <li>asker_captured(asker_gender==Female)->захватила</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nЗаключённые оформили контракт по спасению с фракцией [enemyFaction_name], поэтому они будут отправлять налёты на ваше поселение. [enemyGroupsParagraph]</li>
+    <li>threatsInfo4(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nВраги [asker_nameDef] натравили на заключённых рой механоидов, поэтому они будут на вас регулярно нападать. [enemyGroupsParagraph]</li>
     <li>threatsInfo4(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
     <li>threatsInfo4(generateThreats==false)-></li>
-    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name] попадается в постели с неправильным человеком. [asker_pronoun] заключила под стражу нежелательного любовника в знак его отвержения. Теперь [asker_pronoun] хочет, чтобы вы держали [lodgers0_nameFull] у себя в заключении в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding]</li>
-    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору заплатили фракции [enemyFaction_name] чтобы попытаться вызволить заключённого и пролить свет на историю. [enemyGroupsParagraph]</li>
-    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору спровоцировали механоидов, чтобы те вызволили заключённого и пролили свет на историю. [enemyGroupsParagraph]</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount==1)->[asker_faction_leaderTitle] [asker_nameFull], лидер фракции [asker_faction_name], [asker_wasCaught] в постели с неправильным человеком. В знак публичного отвержения [asker_pronoun] [asker_imprisoned] [lodgers0_lover_gen], [lodgers0_nameFull], под стражу. Теперь [asker_pronoun] хочет, чтобы вы передержали [lodgers0_possessive] у себя в течение [shuttleDelayTicks_duration], пока скандал не уляжется. [allLodgerInfo][threatsInfo5]\n\n[commonDescEnding]</li>
+    <li>asker_wasCaught(asker_gender==Male)->был замечен</li>
+    <li>asker_wasCaught(asker_gender==Female)->была замечена</li>
+    <li>asker_imprisoned(asker_gender==Male)->заключил</li>
+    <li>asker_imprisoned(asker_gender==Female)->заключила</li>
+    <li>lodgers0_lover_gen(lodgers0_gender==Male)->своего любовника</li>
+    <li>lodgers0_lover_gen(lodgers0_gender==Female)->свою любовницу</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору заплатили фракции [enemyFaction_name], чтобы попытаться вызволить [lodgers0_prisoner_gen] и пролить свет на историю. [enemyGroupsParagraph]</li>
+    <li>threatsInfo5(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nК сожалению, противники [asker_nameDef] по двору спровоцировали механоидов, чтобы те вызволили [lodgers0_prisoner_gen] и пролили свет на историю. [enemyGroupsParagraph]</li>
     <li>threatsInfo5(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersSingleHuman]</li>
     <li>threatsInfo5(generateThreats==false)-></li>
-    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_royalTitleInCurrentFaction] [asker_nameFull] из фракции [asker_faction_name], нуждается в вашей помощи. [asker_possessive] придворные археологи недавно извлекли [lodgersCount] заключённых из древнего хранилища крипто-сна, и собираются допросить их. Чтобы сохранить заключённых, как тайну от соперников по двору, [asker_nameDef] хочет, чтобы вы разместили их у себя в течение [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding]</li>
-    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, [enemyFaction_pawnsPlural] из фракции [enemyFaction_name] почитали хранилище, откуда были извлечены заключённые. Они будут отправлять налётчиков любому, кто будет удерживать у себя этих заключённых. [enemyGroupsParagraph]</li>
+    <li>questDescription(asker_royalInCurrentFaction==True,lodgersCount>=2)->[asker_nameFull], [asker_royalTitleInCurrentFaction] из фракции [asker_faction_name], нуждается в вашей помощи. [asker_possessive] придворные археологи недавно извлекли [lodgersCount] заключённых из древнего хранилища криптосна и собираются допросить их. Чтобы сохранить заключённых в тайне от соперников по двору, [asker_nameDef] хочет, чтобы вы разместили их у себя на срок [shuttleDelayTicks_duration]. [allLodgerInfo][threatsInfo6]\n\n[commonDescEnding]</li>
+    <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction!=Mechanoid)->\n\nК сожалению, [enemyFaction_pawnsPlural] из фракции [enemyFaction_name] почитали хранилище, откуда были извлечены заключённые. Они будут отправлять налётчиков к тем, кто будет удерживать у себя этих заключённых. [enemyGroupsParagraph]</li>
     <li>threatsInfo6(generateThreats==true,allowedThreats==Raids,enemyFaction==Mechanoid)->\n\nК сожалению, [enemyFaction_pawnsPlural] из фракции [enemyFaction_name] охраняли хранилище, откуда были извлечены заключённые. Они будут отправлять отряды механоидов, чтобы вернуть обратно утерянных узников. [enemyGroupsParagraph]</li>
     <li>threatsInfo6(generateThreats==true,allowedThreats==MechClusters)->\n\n[threatsInfoMechClustersMultiPrisoners]</li>
     <li>threatsInfo6(generateThreats==false)-></li>
+    <li>lodgers0_prisoner(lodgers0_gender==Male)->заключённый</li>
+    <li>lodgers0_prisoner(lodgers0_gender==Female)->заключённая</li>
+    <li>lodgers0_prisoner_gen(lodgers0_gender==Male)->заключённого</li>
+    <li>lodgers0_prisoner_gen(lodgers0_gender==Female)->заключённую</li>
   </Hospitality_Prisoners.questDescriptionRules.rulesStrings>
   <!-- EN:
     <li>questName->Guarding for [asker_nameDef]</li>
@@ -90,20 +108,16 @@
     <li>adjAny->[AdjectiveFriendly]</li>
   -->
   <Hospitality_Prisoners.questNameRules.rulesStrings>
-    <li>questName->размещение заключённых для [asker_nameDef]</li>
-    <li>questName(lodgersCount==1)->охранять [lodgers0_nameDef]</li>
+    <li>questName->размещение заключённых [asker_nameDef]</li>
+    <li>questName(lodgersCount==1)->охрана [lodgers0_nameDef]</li>
     <li>questName(lodgersCount==1)->заключённый [lodgers0_nameDef]</li>
-    <li>questName(lodgersCount==1)->[adjAny] заключённый</li>
-    <li>questName(lodgersCount==1)->[adjAny] заключённый</li>
+    <li>questName(lodgersCount==1)->[AdjectiveAny] заключённый</li>
     <li>questName(lodgersCount>=2)->наёмный надзиратель</li>
     <li>questName(lodgersCount>=2)->тюремный надзиратель</li>
     <li>questName(lodgersCount>=2)->контрактная тюрьма</li>
     <li>questName(lodgersCount>=2)->разыскиваемые заключённые</li>
-    <li>questName(lodgersCount>=2)->[adjAny] заключённые</li>
-    <li>questName(lodgersCount>=2)->[asker_nameDef]: заключённые</li>
-    <li>adjAny->[AdjectiveBadass]</li>
-    <li>adjAny->[AdjectiveAngsty]</li>
-    <li>adjAny->[AdjectiveFriendly]</li>
+    <li>questName(lodgersCount>=2)->[AdjectiveAny_plural] заключённые</li>
+    <li>questName(lodgersCount>=2)->заключённые [asker_nameDef]</li>
   </Hospitality_Prisoners.questNameRules.rulesStrings>
   
 </LanguageData>

--- a/Royalty/DefInjected/RulePackDef/Script_Hospitality_TextCommon.xml
+++ b/Royalty/DefInjected/RulePackDef/Script_Hospitality_TextCommon.xml
@@ -47,37 +47,44 @@
     <li>lodgersLabelSingOrPlural(lodgersCount>=2)->[lodgersLabelPlural]</li>
     <li>lodgersLabelSingOrPluralDef(lodgersCount==1)->[lodgers0_nameDef]</li>
     <li>lodgersLabelSingOrPluralDef(lodgersCount>=2)->[lodgersLabelPlural]</li>
-    <li>healthInfo(lodgersAreDowned==true,lodgersCount==1,priority=1)->[lodgers0_nameDef] ранен и, вероятно, не сможет ходить.</li>
+    <li>healthInfo(lodgersAreDowned==true,lodgersCount==1,priority=1)->[lodgers0_nameDef] [lodgers0_injured] и, вероятно, не сможет ходить.</li>
     <li>healthInfo(lodgersAreDowned==true,lodgersCount>=2,priority=1)->[lodgersLabelPlural] ранены и, вероятно, не смогут ходить.</li>
-    <li>healthInfo(lodgersAreSick==true,lodgersCount==1,priority=1)->[lodgers0_nameDef] болеет [lodgersDisease_label].</li>
-    <li>healthInfo(lodgersAreSick==true,lodgersCount>=2,priority=1)->[lodgersLabelPlural] болеют [lodgersDisease_label].</li>
+    <li>healthInfo(lodgersAreSick==true,lodgersCount==1,priority=1)->У [lodgers0_nameDef] — [lodgersDisease_label].</li>
+    <li>healthInfo(lodgersAreSick==true,lodgersCount>=2,priority=1)->У [lodgersLabelPlural_gen] — [lodgersDisease_label].</li>
     <li>healthInfo-></li>
-    <li>specialSkillsInfo(lodgersSpecialRequest==ExpertFighter,lodgersCount==1,priority=1)->[lodgers0_nameDef] - опытный боец.</li>
-    <li>specialSkillsInfo(lodgersSpecialRequest==ExpertFighter,lodgersCount>=2,priority=1)->[lodgersLabelPlural] - опытные бойцы.</li>
+    <li>lodgers0_injured(lodgers0_gender==Male)->ранен</li>
+    <li>lodgers0_injured(lodgers0_gender==Female)->ранена</li>
+    <li>specialSkillsInfo(lodgersSpecialRequest==ExpertFighter,lodgersCount==1,priority=1)->[lodgers0_nameDef] — опытный боец.</li>
+    <li>specialSkillsInfo(lodgersSpecialRequest==ExpertFighter,lodgersCount>=2,priority=1)->[lodgersLabelPlural] — опытные бойцы.</li>
     <li>specialSkillsInfo-></li>
-    <li>minMoodInfo(priority=1,lodgersCount==1)->Вам необходимо поддерживать [lodgers0_possessive] настроение выше [lodgersMoodThreshold_percent]</li>
-    <li>minMoodInfo(priority=1,lodgersCount>=2)->Вам необходимо поддерживать [lodgersLabelPlural] настроение выше [lodgersMoodThreshold_percent]</li>
+    <li>minMoodInfo(priority=1,lodgersCount==1)->Вам необходимо поддерживать [lodgers0_possessive] настроение выше [lodgersMoodThreshold_percent].</li>
+    <li>minMoodInfo(priority=1,lodgersCount>=2)->Вам необходимо поддерживать настроение [lodgersLabelPlural_gen] выше [lodgersMoodThreshold_percent].</li>
     <li>minMoodInfo-></li>
     <li>commonDescEnding->[helpersParagraph][shuttleWillComeParagraph]\n\n[mustKeepOnMapParagraph]</li>
-    <li>enemyGroupsParagraph->Налёты будут происходить примерно раз в [threatsIntervalTicks_duration]. Они будут состоять примерно из этого:\n\n[threatExample]</li>
-    <li>shuttleWillComeParagraph(lodgersCount==1)->После [shuttleDelayTicks_duration], прибудет челнок, чтобы забрать [lodgers0_nameDef]. Если [lodgers0_nameDef] попадет в сохранности на челнок, [allRewardsDescriptions]</li>
-    <li>shuttleWillComeParagraph(lodgersCount>=2)->После [shuttleDelayTicks_duration], прибудет челнок, чтобы забрать [lodgersLabelPlural]. Если они попадут на челнок в сохранности, [allRewardsDescriptions]</li>
-    <li>mustKeepOnMapParagraph(lodgersCount==1)->Вы должны разместить [lodgers0_nameDef] в области [map_definite] и не отправлять [lodgers0_nameDef] куда либо ещё</li>
-    <li>mustKeepOnMapParagraph(lodgersCount>=2)->Вы должны разместить [lodgersLabelPlural] в области [map_definite] и не отправлять их куда либо ещё</li>
-    <li>threatsInfoMechClustersSingleHuman->[lodgers0_nameDef] недавно [mechViolation], и преследуется роем механоидов, базирующимся на орбите. До тех пор, пока [lodgers0_nameDef] находится здесь, в область [map_definite] будут регулярно десантироваться кластеры механоидов</li>
-    <li>threatsInfoMechClustersMultiPrisoners->Эти заключённые недавно [mechViolation_pl], и преследуются роем механоидов, базирующимся на орбите. До тех пор, пока они здесь, в область [map_definite] будут регулярно десантироваться кластеры механоидов</li>
-    <li>threatsInfoMechRaidsSingleHuman->[lodgers0_nameDef] недавно [mechViolation], и преследуется роем механоидов. До тех пор, пока [lodgers0_nameDef] находится здесь, механоиды будут совершать регулярные налёты.</li>
-    <li>threatsInfoMechRaidsMultiHuman->Они недавно [mechViolation_pl], и преследуются роем механоидов. Пока они здесь, механоиды будут совершить регулярные налёты.</li>
-    <li>mechViolation->каким-то образом разозлил ИИ-архотека</li>
-    <li>mechViolation->осквернил древний терминал суперкомпьютера</li>
-    <li>mechViolation->убил человеческого ребёнка, обожаемого ИИ-архотеком</li>
-    <li>mechViolation->попытался взломать управляющий узел механоидов</li>
-    <li>mechViolation->попытался совершить кражу из древнего хранилища</li>
-    <li>mechViolation_pl->каким-то образом разозлили ИИ-архотека</li>
-    <li>mechViolation_pl->осквернили древний терминал суперкомпьютера</li>
-    <li>mechViolation_pl->убили человеческого ребёнка, обожаемого ИИ-архотеком</li>
-    <li>mechViolation_pl->попытались взломать управляющий узел механоидов</li>
-    <li>mechViolation_pl->попытались совершить кражу из древнего хранилища</li>
+    <li>enemyGroupsParagraph->Налёты будут происходить примерно раз в [threatsIntervalTicks_duration]. В их составе будут:\n\n[threatExample]</li>
+    <li>shuttleWillComeParagraph(lodgersCount==1)->Через [shuttleDelayTicks_duration] прибудет челнок, чтобы забрать [lodgers0_nameDef]. Если [lodgers0_pronoun] попадёт на челнок в сохранности, [allRewardsDescriptions]</li>
+    <li>shuttleWillComeParagraph(lodgersCount>=2)->Через [shuttleDelayTicks_duration] прибудет челнок, чтобы забрать [lodgersLabelPlural_gen]. Если они попадут на челнок в сохранности, [allRewardsDescriptions]</li>
+    <li>mustKeepOnMapParagraph(lodgersCount==1)->Вы должны разместить [lodgers0_nameDef] в [map_definite] и не отправлять [lodgers0_possessive] куда-либо ещё.</li>
+    <li>mustKeepOnMapParagraph(lodgersCount>=2)->Вы должны разместить [lodgersLabelPlural_gen] в [map_definite] и не отправлять их куда-либо ещё.</li>
+    <li>threatsInfoMechClustersSingleHuman->[lodgers0_nameDef] недавно [lodgers0_mechViolation], и преследуется роем механоидов, базирующимся на орбите. До тех пор, пока [lodgers0_nameDef] находится здесь, на [map_definite] будут регулярно десантироваться кластеры механоидов.</li>
+    <li>threatsInfoMechClustersMultiPrisoners->Эти заключённые недавно [mechViolation_plural], и преследуются роем механоидов, базирующимся на орбите. До тех пор, пока они здесь, на [map_definite] будут регулярно десантироваться кластеры механоидов.</li>
+    <li>threatsInfoMechRaidsSingleHuman->[lodgers0_nameDef] недавно [lodgers0_mechViolation], и преследуется роем механоидов. До тех пор, пока [lodgers0_nameDef] находится здесь, механоиды будут совершать регулярные налёты.</li>
+    <li>threatsInfoMechRaidsMultiHuman->Они недавно [mechViolation_plural], и преследуются роем механоидов. Пока они здесь, механоиды будут совершить регулярные налёты.</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Male)->каким-то образом разозлил ИИ-архотека</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Male)->осквернил древний терминал суперкомпьютера</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Male)->убил человеческого ребёнка, обожаемого ИИ-архотеком</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Male)->попытался взломать управляющий узел механоидов</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Male)->попытался совершить кражу из древнего хранилища</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Female)->каким-то образом разозлила ИИ-архотека</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Female)->осквернила древний терминал суперкомпьютера</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Female)->убила человеческого ребёнка, обожаемого ИИ-архотеком</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Female)->попыталась взломать управляющий узел механоидов</li>
+    <li>lodgers0_mechViolation(lodgers0_gender==Female)->попыталась совершить кражу из древнего хранилища</li>
+    <li>mechViolation_plural->каким-то образом разозлили ИИ-архотека</li>
+    <li>mechViolation_plural->осквернили древний терминал суперкомпьютера</li>
+    <li>mechViolation_plural->убили человеческого ребёнка, обожаемого ИИ-архотеком</li>
+    <li>mechViolation_plural->попытались взломать управляющий узел механоидов</li>
+    <li>mechViolation_plural->попытались совершить кражу из древнего хранилища</li>
     <li>letterSubject->{SUBJECT_definite}</li>
     <li>lodgersHasHave(lodgersCount==1)->имеет</li>
     <li>lodgersHasHave(lodgersCount>=2)->имеют</li>


### PR DESCRIPTION
Квесты, в перевод которых я вставил ^Number( [lodgers0_age] | '#-го года' | '#-х лет' | '#-и лет')^, использующийся в скрипте JoinerThreatCore не вызываются даже в английской версии игры. Очень странно, нужна проверка на других машинах.