### PR TITLE
Config error in DarklightBrazier: description has trailing whitespace

### DIFF
--- a/Royalty/DefInjected/ThingDef/Buildings_Furniture.xml
+++ b/Royalty/DefInjected/ThingDef/Buildings_Furniture.xml
@@ -9,7 +9,7 @@
   <!-- EN: darklight brazier -->
   <DarklightBrazier.label>тусклая жаровня</DarklightBrazier.label>
   <!-- EN: A specially treated brazier that illuminates its surroundings with darklight and creates heat. These satisfy royal brazier requirements. -->
-  <DarklightBrazier.description>Особая жаровня, освещающая окружающее пространство тусклым светом и выделяющая тепло. Такие жаровни, как и обычные, подходят для знати. </DarklightBrazier.description>
+  <DarklightBrazier.description>Особая жаровня, освещающая окружающее пространство тусклым светом и выделяющая тепло. Такие жаровни, как и обычные, подходят для знати.</DarklightBrazier.description>
   
   <!-- EN: drape -->
   <Drape.label>ширма</Drape.label>


### PR DESCRIPTION
Debug log выдаёт следующие ошибки:
 Config error in DarklightBrazier: description has trailing whitespace
 Config error in Frame_DarklightBrazier: description has trailing whitespace