### PR TITLE
Correct blindness precept translation

### DIFF
--- a/Ideology/DefInjected/IssueDef/Precepts_Blindness.xml
+++ b/Ideology/DefInjected/IssueDef/Precepts_Blindness.xml
@@ -2,6 +2,6 @@
 <LanguageData>
   
   <!-- EN: blindness -->
-  <Blindness.label>слепота</Blindness.label>
+  <Blindness.label>ослепление</Blindness.label>
   
 </LanguageData>


### PR DESCRIPTION
Более корректная формулировка. 

"Слепота - осуждается" и тд звучит контринтуитивно и создаёт впечатление, что идеолигия не про неприятие калечущих практик, а про эйблизм и негативное отношение к слепым.

Вынес в отдельный, потому что изменение касается кор механики дополнения.