### PR TITLE
Core 1.5 Keyed 2

### DIFF
--- a/Anomaly/Keyed/ITabs.xml
+++ b/Anomaly/Keyed/ITabs.xml
@@ -35,7 +35,7 @@
   <!-- EN: Amount of knowledge gained per study interval. Better containment helps the researcher focus on study instead of safety, yielding more knowledge. -->
   <StudyKnowledgeGainDesc>Количество знаний, которые можно получить за один период изучения. Чем надёжнее изоляция, тем проще будет учёному сосредоточиться на работе и спокойно ставить эксперименты.</StudyKnowledgeGainDesc>
   <!-- EN: What type of medicine can be given to this entity. -->
-  <MedicineQualityDescriptionEntity>Какие медикаменты можно давать твари.</MedicineQualityDescriptionEntity>
+  <MedicineQualityDescriptionEntity>Какой вид врачебного ухода можно оказывать этой твари.</MedicineQualityDescriptionEntity>
 
   <!-- EN: Electroharvester -->
   <FactorForElectroharvester>Электрожнец</FactorForElectroharvester>

--- a/Core/Keyed/Dialogs_Various.xml
+++ b/Core/Keyed/Dialogs_Various.xml
@@ -1025,7 +1025,7 @@
   <!-- EN: Food policy -->
   <FoodPolicy>Диета</FoodPolicy>
   <!-- EN: Allow food -->
-  <AllowFood>Разрешить еду</AllowFood>
+  <AllowFood>Диета</AllowFood> <!-- Отображается на вкладке "здоровье", рядом с дропдауном выбора диеты. Выглядит как "Диета: шикарная". Вариант "разрешить еду" некрасив и не единообразен с соседней строкой "уход" -->
   <!-- EN: Lavish -->
   <FoodRestrictionLavish>Шикарная</FoodRestrictionLavish>
   <!-- EN: Fine -->

--- a/Core/Keyed/Enums.xml
+++ b/Core/Keyed/Enums.xml
@@ -149,7 +149,7 @@
   
   <!-- Medical care category -->
   <!-- EN: no medical care -->
-  <MedicalCareCategory_NoCare>без медицинской помощи</MedicalCareCategory_NoCare>
+  <MedicalCareCategory_NoCare>без врачебного ухода</MedicalCareCategory_NoCare>
   <!-- EN: doctor care, but no medicine -->
   <MedicalCareCategory_NoMeds>врачебный уход без лекарств</MedicalCareCategory_NoMeds>
   <!-- EN: herbal medicine or worse -->

--- a/Core/Keyed/FloatMenu.xml
+++ b/Core/Keyed/FloatMenu.xml
@@ -434,15 +434,15 @@
   <TradeWithSettlement>Торговать с {0}</TradeWithSettlement>
   
   <!-- EN: Enter {0} -->
-  <EnterPortal>Войти в {lookup: {0}; Case; 3}</EnterPortal>
+  <EnterPortal>Пройти через {lookup: {0}; Case; 3}</EnterPortal>
   <!-- EN: Entering {0} -->
-  <EnteringPortal>Входит в {lookup: {0}; Case; 3}</EnteringPortal>
+  <EnteringPortal>Проходит через {lookup: {0}; Case; 3}</EnteringPortal>
   <!-- EN: Enter {0} -->
-  <CommandEnterPortal>Войти в {lookup: {0}; Case; 3}</CommandEnterPortal>
+  <CommandEnterPortal>Пройти через {lookup: {0}; Case; 3}</CommandEnterPortal>
   <!-- EN: Select people and items to enter the {0}. -->
-  <CommandEnterPortalDesc>Выберите людей и вещи для входа в {lookup: {0}; Case; 3}.</CommandEnterPortalDesc>
+  <CommandEnterPortalDesc>Выберите людей и вещи для прохода через {lookup: {0}; Case; 3}.</CommandEnterPortalDesc>
   <!-- EN: Cancel entering -->
-  <CommandCancelEnterPortal>Отменить вход</CommandCancelEnterPortal>
+  <CommandCancelEnterPortal>Отменить проход</CommandCancelEnterPortal>
   <!-- EN: Cancel loading people or items into this. -->
   <CommandCancelEnterPortalDesc>Отменить проход людей и пронос вещей.</CommandCancelEnterPortalDesc>
 

--- a/Core/Keyed/GameplayCommands.xml
+++ b/Core/Keyed/GameplayCommands.xml
@@ -244,9 +244,9 @@
   
   <!-- Firefoam popper -->
   <!-- EN: Auto rebuild -->
-  <CommandAutoRebuild_Building>TODO</CommandAutoRebuild_Building>
+  <CommandAutoRebuild_Building>Автозамена</CommandAutoRebuild_Building>
   <!-- EN: If this is on, {BUILDING_definite} will automatically be replaced after it detonates. -->
-  <CommandAutoRebuild_BuildingDesc>TODO</CommandAutoRebuild_BuildingDesc>
+  <CommandAutoRebuild_BuildingDesc>Если активно, то после срабатывания {BUILDING_definite} будет автоматически назначаться для замены.</CommandAutoRebuild_BuildingDesc>
   
   <!-- Animal control -->
   <!-- EN: Animals attack -->
@@ -320,13 +320,13 @@
 
   <!-- Send caravan -->
   <!-- EN: Send caravan -->
-  <CommandSendCaravan>TODO</CommandSendCaravan>
+  <CommandSendCaravan>Отправить караван</CommandSendCaravan>
   <!-- EN: Send caravan... -->
-  <CommandSendCaravanMultiple>TODO</CommandSendCaravanMultiple>
+  <CommandSendCaravanMultiple>Отправить караван...</CommandSendCaravanMultiple>
   <!-- EN: Send a caravan to this destination from a selected colony which can reach this location. -->
-  <CommandSendCaravanDesc>TODO</CommandSendCaravanDesc>
+  <CommandSendCaravanDesc>Отправить караван к этому месту из выбранного поселения, для которого это место достижимо.</CommandSendCaravanDesc>
   <!-- EN: Your settlements have no path to this location. -->
-  <CommandSendCaravanCantReach>TODO</CommandSendCaravanCantReach>
+  <CommandSendCaravanCantReach>Ваши поселенцы не могут добраться до этого места.</CommandSendCaravanCantReach>
 
   <!-- Split caravan -->
   <!-- EN: Split -->
@@ -643,7 +643,7 @@
   <!-- EN: Linked storage settings -->
   <LinkedStorageSettings>Сгруппировано</LinkedStorageSettings>
   <!-- EN: 1 building -->
-  <OneBuilding>TODO</OneBuilding>
+  <OneBuilding>1 хранилище</OneBuilding>
   <!-- EN: {0} buildings -->
   <NumBuildings>{0_numCase ? хранилище : хранилища : хранилищ}</NumBuildings>
   <!-- EN: Stores -->
@@ -658,13 +658,13 @@
 
   <!-- Study -->
   <!-- EN: Toggle study -->
-  <CommandToggleStudy>TODO</CommandToggleStudy>
+  <CommandToggleStudy>Разрешить изучение</CommandToggleStudy>
   <!-- EN: Determines whether or not wardens will automatically study this. Forbidden things will never be studied. -->
-  <CommandToggleStudyDesc>TODO</CommandToggleStudyDesc>
+  <CommandToggleStudyDesc>Будут ли надзиратели самостоятельно изучать этот объект. Запрещённые предметы никто не будет изучать.</CommandToggleStudyDesc>
 
   <!-- Limited use count action -->
   <!-- EN: No uses left. -->
-  <CommandNoUsesLeft>TODO</CommandNoUsesLeft>
+  <CommandNoUsesLeft>Использований не осталось.</CommandNoUsesLeft>
   
   <!-- UNUSED -->
   <CommandRenameZoneLabel>Сменить название</CommandRenameZoneLabel>

--- a/Core/Keyed/GameplayCommands.xml
+++ b/Core/Keyed/GameplayCommands.xml
@@ -242,6 +242,12 @@
   <!-- EN: If this is on, this trap will automatically be replaced after it springs. -->
   <CommandAutoRearmDesc>Если активно, то после срабатывания ловушка будет автоматически назначаться для замены.</CommandAutoRearmDesc>
   
+  <!-- Firefoam popper -->
+  <!-- EN: Auto rebuild -->
+  <CommandAutoRebuild_Building>TODO</CommandAutoRebuild_Building>
+  <!-- EN: If this is on, {BUILDING_definite} will automatically be replaced after it detonates. -->
+  <CommandAutoRebuild_BuildingDesc>TODO</CommandAutoRebuild_BuildingDesc>
+  
   <!-- Animal control -->
   <!-- EN: Animals attack -->
   <CommandReleaseAnimalsLabel>Натравить</CommandReleaseAnimalsLabel>
@@ -311,7 +317,17 @@
   <CommandReformCaravanDesc>Продолжить путь. Путешественники покинут место, в котором находятся, и будут ждать дальнейших указаний.</CommandReformCaravanDesc>
   <!-- EN: There are still some enemies in this area. -->
   <CommandReformCaravanFailHostilePawns>Неподалёку ещё есть противники.</CommandReformCaravanFailHostilePawns>
-  
+
+  <!-- Send caravan -->
+  <!-- EN: Send caravan -->
+  <CommandSendCaravan>TODO</CommandSendCaravan>
+  <!-- EN: Send caravan... -->
+  <CommandSendCaravanMultiple>TODO</CommandSendCaravanMultiple>
+  <!-- EN: Send a caravan to this destination from a selected colony which can reach this location. -->
+  <CommandSendCaravanDesc>TODO</CommandSendCaravanDesc>
+  <!-- EN: Your settlements have no path to this location. -->
+  <CommandSendCaravanCantReach>TODO</CommandSendCaravanCantReach>
+
   <!-- Split caravan -->
   <!-- EN: Split -->
   <CommandSplitCaravan>Разделиться</CommandSplitCaravan>
@@ -626,6 +642,8 @@
   <UnlinkStorageSettingsDesc>Отмена группировки позволит устанавливать отдельные настройки для этого хранилища.</UnlinkStorageSettingsDesc>
   <!-- EN: Linked storage settings -->
   <LinkedStorageSettings>Сгруппировано</LinkedStorageSettings>
+  <!-- EN: 1 building -->
+  <OneBuilding>TODO</OneBuilding>
   <!-- EN: {0} buildings -->
   <NumBuildings>{0_numCase ? хранилище : хранилища : хранилищ}</NumBuildings>
   <!-- EN: Stores -->
@@ -637,5 +655,19 @@
 
   <!-- EN: {0_labelShort} is unconscious. -->
   <CommandDisabledUnconscious>{0_labelShort} без сознания.</CommandDisabledUnconscious>
+
+  <!-- Study -->
+  <!-- EN: Toggle study -->
+  <CommandToggleStudy>TODO</CommandToggleStudy>
+  <!-- EN: Determines whether or not wardens will automatically study this. Forbidden things will never be studied. -->
+  <CommandToggleStudyDesc>TODO</CommandToggleStudyDesc>
+
+  <!-- Limited use count action -->
+  <!-- EN: No uses left. -->
+  <CommandNoUsesLeft>TODO</CommandNoUsesLeft>
   
+  <!-- UNUSED -->
+  <CommandRenameZoneLabel>Сменить название</CommandRenameZoneLabel>
+  <CommandRenameZoneDesc>Переименовать область.</CommandRenameZoneDesc>
+
 </LanguageData>

--- a/Core/Keyed/GameplayCommands.xml
+++ b/Core/Keyed/GameplayCommands.xml
@@ -246,7 +246,7 @@
   <!-- EN: Auto rebuild -->
   <CommandAutoRebuild_Building>Автозамена</CommandAutoRebuild_Building>
   <!-- EN: If this is on, {BUILDING_definite} will automatically be replaced after it detonates. -->
-  <CommandAutoRebuild_BuildingDesc>Если активно, то после срабатывания {BUILDING_definite} будет автоматически назначаться для замены.</CommandAutoRebuild_BuildingDesc>
+  <CommandAutoRebuild_BuildingDesc>Если активно, то {BUILDING_definite} будет автоматически назначаться для замены после срабатывания.</CommandAutoRebuild_BuildingDesc>
   
   <!-- Animal control -->
   <!-- EN: Animals attack -->
@@ -324,7 +324,7 @@
   <!-- EN: Send caravan... -->
   <CommandSendCaravanMultiple>Отправить караван...</CommandSendCaravanMultiple>
   <!-- EN: Send a caravan to this destination from a selected colony which can reach this location. -->
-  <CommandSendCaravanDesc>Отправить караван к этому месту из выбранного поселения, для которого это место достижимо.</CommandSendCaravanDesc>
+  <CommandSendCaravanDesc>Отправить к этому месту караван из поселения, от которого это место достижимо.</CommandSendCaravanDesc>
   <!-- EN: Your settlements have no path to this location. -->
   <CommandSendCaravanCantReach>Ваши поселенцы не могут добраться до этого места.</CommandSendCaravanCantReach>
 

--- a/Core/Keyed/Grammar.xml
+++ b/Core/Keyed/Grammar.xml
@@ -49,6 +49,13 @@
   <!-- EN: It -->
   <ProitCap>Оно</ProitCap>
 
+  <!-- EN: man -->
+  <ProHeNoun>TODO</ProHeNoun>
+  <!-- EN: woman -->
+  <ProSheNoun>TODO</ProSheNoun>
+  <!-- EN: person -->
+  <ProItNoun>TODO</ProItNoun>
+  
   <!-- EN: {0} and {1}. -->
   <ClauseSequence2>{0} и {1}.</ClauseSequence2>
   <!-- EN: {0}. Also, {1} and {2}. -->

--- a/Core/Keyed/Grammar.xml
+++ b/Core/Keyed/Grammar.xml
@@ -50,11 +50,11 @@
   <ProitCap>Оно</ProitCap>
 
   <!-- EN: man -->
-  <ProHeNoun>TODO</ProHeNoun>
+  <ProHeNoun>мужчина</ProHeNoun>
   <!-- EN: woman -->
-  <ProSheNoun>TODO</ProSheNoun>
+  <ProSheNoun>женщина</ProSheNoun>
   <!-- EN: person -->
-  <ProItNoun>TODO</ProItNoun>
+  <ProItNoun>человек</ProItNoun>
   
   <!-- EN: {0} and {1}. -->
   <ClauseSequence2>{0} и {1}.</ClauseSequence2>

--- a/Core/Keyed/ITabs.xml
+++ b/Core/Keyed/ITabs.xml
@@ -48,8 +48,14 @@
   <TabFormingCaravan>Караван</TabFormingCaravan>
   <!-- EN: Contents -->
   <TabTransporterContents>Груз</TabTransporterContents>
+  <!-- EN: Travel -->
+  <TabMapPortalContents>TODO</TabMapPortalContents>
   <!-- EN: Contents -->
   <TabCasketContents>Содержимое</TabCasketContents>
+  <!-- EN: Details -->
+  <TabBookContents>TODO</TabBookContents>
+  <!-- EN: Study -->
+  <TabStudyNotesContents>TODO</TabStudyNotesContents>
   <!-- EN: Auto-cut -->
   <TabWindTurbineAutoCut>Растения</TabWindTurbineAutoCut>
   
@@ -138,6 +144,8 @@
   <NonRecruitable>Невозможно завербовать</NonRecruitable>
   <!-- EN: This prisoner is so unwaveringly loyal to their home that they refuse to be recruited entirely. -->
   <NonRecruitableTip>Верность этого пленника своей фракции непоколебима, его невозможно завербовать.</NonRecruitableTip>
+  <!-- EN: What type of medicine can be given to this prisoner. -->
+  <MedicineQualityDescriptionPrisoner>TODO</MedicineQualityDescriptionPrisoner>
 
 
 
@@ -219,7 +227,13 @@
   <AllowSelfTendTip>{0} будут самостоятельно лечиться на месте с эффективностью {1} от нормальной.</AllowSelfTendTip>
   <!-- EN: death in {0} -->
   <DeathIn>смерть через {0}</DeathIn>
-  
+  <!-- EN: Allow medicine -->
+  <AllowMedicine>TODO</AllowMedicine>
+  <!-- EN: What type of medicine can be given to this person. -->
+  <MedicineQualityDescription>TODO</MedicineQualityDescription>
+  <!-- EN: What type of food can be given to this person. -->
+  <FoodRestrictionDescription>TODO</FoodRestrictionDescription>
+
   <!-- Medical - Body and activities condition -->
   <!-- EN: None -->
   <None>Нет</None>
@@ -422,5 +436,17 @@
 
   <!-- EN: Auto-cut blocking plants -->
   <WindTurbineAutoCut_EnabledCheckbox>Рубить мешающие растения</WindTurbineAutoCut_EnabledCheckbox>
+  
+  <!-- Study tab  -->
+  <!-- EN: Study progress -->
+  <StudyNotesTab_StudyProgress>TODO</StudyNotesTab_StudyProgress>
+  <!-- EN: Ongoing -->
+  <StudyNotesTab_StudyProgressOngoing>TODO</StudyNotesTab_StudyProgressOngoing>
+  <!-- EN: Completed -->
+  <StudyNotesTab_StudyProgressCompleted>TODO</StudyNotesTab_StudyProgressCompleted>
+  <!-- EN: Toggle study -->
+  <StudyNotesTab_ToggleStudy>TODO</StudyNotesTab_ToggleStudy>
+  <!-- EN: No discoveries yet -->
+  <StudyNotesTab_NoDiscoveries>TODO</StudyNotesTab_NoDiscoveries>
 
 </LanguageData>

--- a/Core/Keyed/ITabs.xml
+++ b/Core/Keyed/ITabs.xml
@@ -49,13 +49,13 @@
   <!-- EN: Contents -->
   <TabTransporterContents>Груз</TabTransporterContents>
   <!-- EN: Travel -->
-  <TabMapPortalContents>TODO</TabMapPortalContents>
+  <TabMapPortalContents>Переход</TabMapPortalContents>
   <!-- EN: Contents -->
   <TabCasketContents>Содержимое</TabCasketContents>
   <!-- EN: Details -->
-  <TabBookContents>TODO</TabBookContents>
+  <TabBookContents>Детали</TabBookContents>
   <!-- EN: Study -->
-  <TabStudyNotesContents>TODO</TabStudyNotesContents>
+  <TabStudyNotesContents>Изучение</TabStudyNotesContents>
   <!-- EN: Auto-cut -->
   <TabWindTurbineAutoCut>Растения</TabWindTurbineAutoCut>
   
@@ -145,7 +145,7 @@
   <!-- EN: This prisoner is so unwaveringly loyal to their home that they refuse to be recruited entirely. -->
   <NonRecruitableTip>Верность этого пленника своей фракции непоколебима, его невозможно завербовать.</NonRecruitableTip>
   <!-- EN: What type of medicine can be given to this prisoner. -->
-  <MedicineQualityDescriptionPrisoner>TODO</MedicineQualityDescriptionPrisoner>
+  <MedicineQualityDescriptionPrisoner>Какой вид врачебного ухода можно оказывать этом пленнику.</MedicineQualityDescriptionPrisoner>
 
 
 
@@ -228,11 +228,11 @@
   <!-- EN: death in {0} -->
   <DeathIn>смерть через {0}</DeathIn>
   <!-- EN: Allow medicine -->
-  <AllowMedicine>TODO</AllowMedicine>
+  <AllowMedicine>Уход</AllowMedicine> <!-- Отображается на вкладке "здоровье", рядом с дропдауном выбора врачебного ухода. "Разрешить уход" не умещается -->
   <!-- EN: What type of medicine can be given to this person. -->
-  <MedicineQualityDescription>TODO</MedicineQualityDescription>
+  <MedicineQualityDescription>Какой вид врачебного ухода можно оказывать этом человеку.</MedicineQualityDescription>
   <!-- EN: What type of food can be given to this person. -->
-  <FoodRestrictionDescription>TODO</FoodRestrictionDescription>
+  <FoodRestrictionDescription>Какую еду можно давать этом человеку.</FoodRestrictionDescription>
 
   <!-- Medical - Body and activities condition -->
   <!-- EN: None -->
@@ -439,14 +439,14 @@
   
   <!-- Study tab  -->
   <!-- EN: Study progress -->
-  <StudyNotesTab_StudyProgress>TODO</StudyNotesTab_StudyProgress>
+  <StudyNotesTab_StudyProgress>Изучение</StudyNotesTab_StudyProgress> <!-- Формируется строка вида "Изучение: в процессе" -->
   <!-- EN: Ongoing -->
-  <StudyNotesTab_StudyProgressOngoing>TODO</StudyNotesTab_StudyProgressOngoing>
+  <StudyNotesTab_StudyProgressOngoing>в процессе</StudyNotesTab_StudyProgressOngoing>
   <!-- EN: Completed -->
-  <StudyNotesTab_StudyProgressCompleted>TODO</StudyNotesTab_StudyProgressCompleted>
+  <StudyNotesTab_StudyProgressCompleted>завершено</StudyNotesTab_StudyProgressCompleted>
   <!-- EN: Toggle study -->
-  <StudyNotesTab_ToggleStudy>TODO</StudyNotesTab_ToggleStudy>
+  <StudyNotesTab_ToggleStudy>Изучать</StudyNotesTab_ToggleStudy> <!-- отображается рядом с чекбоксом -->
   <!-- EN: No discoveries yet -->
-  <StudyNotesTab_NoDiscoveries>TODO</StudyNotesTab_NoDiscoveries>
+  <StudyNotesTab_NoDiscoveries>Пока нет открытий</StudyNotesTab_NoDiscoveries>
 
 </LanguageData>

--- a/Core/Keyed/Menus_Main.xml
+++ b/Core/Keyed/Menus_Main.xml
@@ -643,7 +643,7 @@
   <!-- EN: Caused by gene -->
   <IncapableOfTooltipGene>Из-за гена</IncapableOfTooltipGene>
   <!-- EN: Caused by -->
-  <IncapableOfTooltipMutant>TODO</IncapableOfTooltipMutant>
+  <IncapableOfTooltipMutant>Из-за</IncapableOfTooltipMutant>
   <!-- EN: Traits -->
   <Traits>Черты характера</Traits>
   <!-- EN: Permanent mood effect -->

--- a/Core/Keyed/Menus_Main.xml
+++ b/Core/Keyed/Menus_Main.xml
@@ -642,6 +642,8 @@
   <IncapableOfTooltipRole>Из-за роли</IncapableOfTooltipRole>
   <!-- EN: Caused by gene -->
   <IncapableOfTooltipGene>Из-за гена</IncapableOfTooltipGene>
+  <!-- EN: Caused by -->
+  <IncapableOfTooltipMutant>TODO</IncapableOfTooltipMutant>
   <!-- EN: Traits -->
   <Traits>Черты характера</Traits>
   <!-- EN: Permanent mood effect -->

--- a/Core/Keyed/Messages.xml
+++ b/Core/Keyed/Messages.xml
@@ -817,7 +817,7 @@
   <StorageSettingsPastedFromClipboard>Настройки хранилища вставлены из буфера обмена.</StorageSettingsPastedFromClipboard>
   
   <!-- EN: {0_label} requires adjacent walls to function. -->
-  <MessageBuildingRequiresAdjacentWalls>Для установки {lookup: {0_label}; Case; 1} нужны стены с обеих сторон.</MessageBuildingRequiresAdjacentWalls>
+  <MessageBuildingRequiresAdjacentWalls>Для работы {lookup: {0_label}; Case; 1} нужны стены с обеих сторон.</MessageBuildingRequiresAdjacentWalls>
 
   <!-- EN: Cannot skip: Refugee -->
   <MessageLodgersCantFarskip>Невозможно прыгнуть: беженец</MessageLodgersCantFarskip>

--- a/Core/Keyed/Messages.xml
+++ b/Core/Keyed/Messages.xml
@@ -13,6 +13,9 @@
   <!-- EN: {0} from {1} have decided to steal what they can and leave. -->
   <MessageRaidersStealing>{0} из фракции {1} решили украсть, что смогут, и уйти.</MessageRaidersStealing>
 
+  <!-- EN: The mechanoids sense no more targets and are moving on. -->
+  <MechanoidsMovingOn>TODO</MechanoidsMovingOn>
+
   <!-- EN: {0} from {1} have arrived and are attacking! More are on the way and will arrive in {2}. -->
   <MessageCaravanDetectedRaidArrived>{0} из фракции {1} нападают на ваш караван! Через {2} прибудут их новые подкрепления.</MessageCaravanDetectedRaidArrived>
 
@@ -34,6 +37,8 @@
   <MessageVisitorsTrappedLeaving>{0} из фракции {1} попали в ловушку и пытаются выбраться на свободу.</MessageVisitorsTrappedLeaving>
   <!-- EN: {0} from {1} are leaving the map because of dangerous temperature. -->
   <MessageVisitorsDangerousTemperature>{0} из фракции {1} уходят из-за опасных температурных условий.</MessageVisitorsDangerousTemperature>
+  <!-- EN: {0} from {1} are leaving the map because of dangerous weather. -->
+  <MessageVisitorsAnomalousWeather>TODO</MessageVisitorsAnomalousWeather>
 
   <!-- EN: {0} worn by {1_nameFull} deteriorated away to nothing. -->
   <MessageWornApparelDeterioratedAway>{0}, {0_gender ? который : которую : которое} {1_gender ? носил : носила} {1_nameFull}, {0_gender ? износился : износилась : износилось} окончательно и {0_gender ? рассыпался : рассыпалась : рассыпалось} в прах.</MessageWornApparelDeterioratedAway>
@@ -125,6 +130,10 @@
   <MessageMustDesignateDeconstructibleMechCluster>Вам нужно разгромить кластер механоидов, прежде чем разбирать его.</MessageMustDesignateDeconstructibleMechCluster>
   <!-- EN: Must designate rough stone surfaces. -->
   <MessageMustDesignateSmoothableSurface>Нужно указать неровную каменную поверхность.</MessageMustDesignateSmoothableSurface>
+  <!-- EN: Must designate rough stone terrain. -->
+  <MessageMustDesignateSmoothableFloor>TODO</MessageMustDesignateSmoothableFloor>
+  <!-- EN: Must designate rough stone wall. -->
+  <MessageMustDesignateSmoothableWall>TODO</MessageMustDesignateSmoothableWall>
   <!-- EN: Nothing can remove thick roofs. -->
   <MessageNothingCanRemoveThickRoofs>Потолок в виде толстой горной породы удалить невозможно.</MessageNothingCanRemoveThickRoofs>
   <!-- EN: This is already in storage and will be moved to high-priority storage as necessary. -->
@@ -186,7 +195,7 @@
   <!-- EN: {PAWN_labelShort} has exceeded the normal limit of neural heat. -->
   <MessageWentOverPsychicEntropyLimit>{PAWN_labelShort} {PAWN_gender ? превысил : превысила} безопасный порог нейроперегрева.</MessageWentOverPsychicEntropyLimit>
 
-  <!-- EN: No handler can tame {ANIMAL_kindBase} (requires level {1} in {2}, best handler {HANDLER_labelShort} has {4}). -->
+  <!-- EN: No handler capable of taming {ANIMAL_kindBase} (requires level {1} in {2}, best capable handler {HANDLER_labelShort} has {4}). -->
   <MessageNoHandlerSkilledEnough>Никто не сможет приручить {ANIMAL_kindBase}. Требуется {2} уровня {1}. Лучший животновод, {HANDLER_labelShort}, имеет уровень {4}.</MessageNoHandlerSkilledEnough>
   
   <!-- EN: {EATEN_labelShort} has been eaten by {PREDATOR}. -->
@@ -202,7 +211,9 @@
   
   <!-- EN: The trade caravan from {0} is leaving. -->
   <MessageTraderCaravanLeaving>Торговый караван из фракции {0} уходит.</MessageTraderCaravanLeaving>
-  
+  <!-- EN: The trade caravan from {0} has been dismissed. -->
+  <MessageTraderCaravanDismissed>TODO</MessageTraderCaravanDismissed>
+
   <!-- EN: {1_labelShort} is dead. -->
   <MessageCantSelectDeadPawn>{1_labelShort} {1_gender ? мёртв : мертва}.</MessageCantSelectDeadPawn>
   <!-- EN: {1_labelShort} is off the map. -->
@@ -346,6 +357,8 @@
 
   <!-- EN: Your {1} can't finish loading the transport pods because some items or people became unavailable ({2_labelShort}). -->
   <MessageCantLoadMoreIntoTransporters>Ваши {1} не могут завершить погрузку из-за отсутствия доступа к некоторым людям или вещам: {2_labelShort}.</MessageCantLoadMoreIntoTransporters>
+  <!-- EN: Your {1} can't finish entering the {0} because some items or people became unavailable ({2_labelShort}). -->
+  <MessageCantLoadMoreIntoPortal>TODO</MessageCantLoadMoreIntoPortal>
   
   <!-- EN: Selected destination is invalid. -->
   <MessageTransportPodsDestinationIsInvalid>Выбрано неподходящее место назначения.</MessageTransportPodsDestinationIsInvalid>
@@ -563,6 +576,10 @@
   <MessageBillValidationPawnUnavailable>{0} больше не может работать над задачей «{1}». Ограничение снято.</MessageBillValidationPawnUnavailable>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted stockpile {2}. -->
   <MessageBillValidationIncludeZoneDeleted>Невозможно посчитать число предметов, указанное для задачи «{0}», поскольку область {2} была удалена.</MessageBillValidationIncludeZoneDeleted>
+  <!-- EN: {1}'s "{0}" can no longer count items in deleted building {2}. -->
+  <MessageBillValidationIncludeBuildingDeleted>TODO</MessageBillValidationIncludeBuildingDeleted>
+  <!-- EN: {1}'s "{0}" can no longer count items in deleted storage group {2}. -->
+  <MessageBillValidationIncludeStorageGroupDeleted>TODO</MessageBillValidationIncludeStorageGroupDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in unavailable stockpile {2}. -->
   <MessageBillValidationIncludeZoneUnavailable>Невозможно посчитать число предметов, указанное для задачи «{0}», поскольку {2} вне досягаемости.</MessageBillValidationIncludeZoneUnavailable>
   <!-- EN: {1}'s "{0}" can no longer deliver all products to stockpile {2}. -->
@@ -733,6 +750,8 @@
   <MessageRitualRoleMustHaveIdeoToDoRole>только {0} может брать роль «{1}».</MessageRitualRoleMustHaveIdeoToDoRole>
   <!-- EN: must be colonist for the {0} role. -->
   <MessageRitualRoleMustBeColonist>До роли «{0}» допускаются только поселенцы.</MessageRitualRoleMustBeColonist>
+  <!-- EN: must not be a prisoner for the {0} role. -->
+  <MessageRitualRoleMustBeFree>TODO</MessageRitualRoleMustBeFree>
   <!-- EN: {0_labelShort} won't attend due to extreme temperature in the ritual area. -->
   <MessageRitualWontAttendExtremeTemperature>{0_labelShort} не придёт из-за экстремальной температуры в месте проведения ритуала.</MessageRitualWontAttendExtremeTemperature>
   <!-- EN: must be colonist and not enslaved for the {0} role. -->
@@ -753,6 +772,8 @@
   <MessageRitualRoleCannotBeChild>{0} не может быть ребёнком.</MessageRitualRoleCannotBeChild>
   <!-- EN: {0} cannot be a baby. -->
   <MessageRitualRoleCannotBeBaby>{0} не может быть младенцем.</MessageRitualRoleCannotBeBaby>
+  <!-- EN: {0} is busy. -->
+  <MessageRitualRoleBusy>TODO</MessageRitualRoleBusy>
 
   <!-- EN: You must select a site to continue. -->
   <MessagePlayerMustSelectTile>Перед тем, как продолжить, выберите место.</MessagePlayerMustSelectTile>
@@ -784,11 +805,21 @@
 
   <!-- EN: Storage settings linked for {0} buildings. -->
   <SettingsLinkedFor>Сгруппировано {0_numCase ? сооружение : сооружения : сооружений}.</SettingsLinkedFor>
+  <!-- EN: Storage settings linked for 1 building. -->
+  <SettingsLinkedForSingular>TODO</SettingsLinkedForSingular>
   <!-- EN: Storage settings unlinked for {0} buildings. -->
   <SettingsUnlinkedFor>Группировка отменена для {0_numCase ? сооружения : сооружений : сооружений}.</SettingsUnlinkedFor>
+  <!-- EN: Storage settings unlinked for 1 building. -->
+  <SettingsUnlinkedForSingular>TODO</SettingsUnlinkedForSingular>
   <!-- EN: Storage settings copied to clipboard. -->
   <StorageSettingsCopiedToClipboard>Настройки хранилища скопированы в буфер обмена.</StorageSettingsCopiedToClipboard>
   <!-- EN: Storage settings pasted from clipboard. -->
   <StorageSettingsPastedFromClipboard>Настройки хранилища вставлены из буфера обмена.</StorageSettingsPastedFromClipboard>
+  
+  <!-- EN: {0_label} requires adjacent walls to function. -->
+  <MessageBuildingRequiresAdjacentWalls>TODO</MessageBuildingRequiresAdjacentWalls>
+
+  <!-- EN: Cannot skip: Refugee -->
+  <MessageLodgersCantFarskip>TODO</MessageLodgersCantFarskip>
 
 </LanguageData>

--- a/Core/Keyed/Messages.xml
+++ b/Core/Keyed/Messages.xml
@@ -14,7 +14,7 @@
   <MessageRaidersStealing>{0} из фракции {1} решили украсть, что смогут, и уйти.</MessageRaidersStealing>
 
   <!-- EN: The mechanoids sense no more targets and are moving on. -->
-  <MechanoidsMovingOn>TODO</MechanoidsMovingOn>
+  <MechanoidsMovingOn>Механоиды не видят новых целей и уходят.</MechanoidsMovingOn>
 
   <!-- EN: {0} from {1} have arrived and are attacking! More are on the way and will arrive in {2}. -->
   <MessageCaravanDetectedRaidArrived>{0} из фракции {1} нападают на ваш караван! Через {2} прибудут их новые подкрепления.</MessageCaravanDetectedRaidArrived>
@@ -38,7 +38,7 @@
   <!-- EN: {0} from {1} are leaving the map because of dangerous temperature. -->
   <MessageVisitorsDangerousTemperature>{0} из фракции {1} уходят из-за опасных температурных условий.</MessageVisitorsDangerousTemperature>
   <!-- EN: {0} from {1} are leaving the map because of dangerous weather. -->
-  <MessageVisitorsAnomalousWeather>TODO</MessageVisitorsAnomalousWeather>
+  <MessageVisitorsAnomalousWeather>{0} из фракции {1} уходят из-за опасных погодных условий.</MessageVisitorsAnomalousWeather>
 
   <!-- EN: {0} worn by {1_nameFull} deteriorated away to nothing. -->
   <MessageWornApparelDeterioratedAway>{0}, {0_gender ? который : которую : которое} {1_gender ? носил : носила} {1_nameFull}, {0_gender ? износился : износилась : износилось} окончательно и {0_gender ? рассыпался : рассыпалась : рассыпалось} в прах.</MessageWornApparelDeterioratedAway>
@@ -129,11 +129,11 @@
   <!-- EN: You must defeat a mech cluster before you can deconstruct it. -->
   <MessageMustDesignateDeconstructibleMechCluster>Вам нужно разгромить кластер механоидов, прежде чем разбирать его.</MessageMustDesignateDeconstructibleMechCluster>
   <!-- EN: Must designate rough stone surfaces. -->
-  <MessageMustDesignateSmoothableSurface>Нужно указать неровную каменную поверхность.</MessageMustDesignateSmoothableSurface>
+  <MessageMustDesignateSmoothableSurface>Нужно указать необработанную каменную поверхность.</MessageMustDesignateSmoothableSurface>
   <!-- EN: Must designate rough stone terrain. -->
-  <MessageMustDesignateSmoothableFloor>TODO</MessageMustDesignateSmoothableFloor>
+  <MessageMustDesignateSmoothableFloor>Нужно указать необработанный каменный пол.</MessageMustDesignateSmoothableFloor>
   <!-- EN: Must designate rough stone wall. -->
-  <MessageMustDesignateSmoothableWall>TODO</MessageMustDesignateSmoothableWall>
+  <MessageMustDesignateSmoothableWall>Нужно указать необработанную каменную стену.</MessageMustDesignateSmoothableWall>
   <!-- EN: Nothing can remove thick roofs. -->
   <MessageNothingCanRemoveThickRoofs>Потолок в виде толстой горной породы удалить невозможно.</MessageNothingCanRemoveThickRoofs>
   <!-- EN: This is already in storage and will be moved to high-priority storage as necessary. -->
@@ -212,7 +212,7 @@
   <!-- EN: The trade caravan from {0} is leaving. -->
   <MessageTraderCaravanLeaving>Торговый караван из фракции {0} уходит.</MessageTraderCaravanLeaving>
   <!-- EN: The trade caravan from {0} has been dismissed. -->
-  <MessageTraderCaravanDismissed>TODO</MessageTraderCaravanDismissed>
+  <MessageTraderCaravanDismissed>Вы отказались от торговли с караваном из фракции {0} — он уходит.</MessageTraderCaravanDismissed>
 
   <!-- EN: {1_labelShort} is dead. -->
   <MessageCantSelectDeadPawn>{1_labelShort} {1_gender ? мёртв : мертва}.</MessageCantSelectDeadPawn>
@@ -358,7 +358,7 @@
   <!-- EN: Your {1} can't finish loading the transport pods because some items or people became unavailable ({2_labelShort}). -->
   <MessageCantLoadMoreIntoTransporters>Ваши {1} не могут завершить погрузку из-за отсутствия доступа к некоторым людям или вещам: {2_labelShort}.</MessageCantLoadMoreIntoTransporters>
   <!-- EN: Your {1} can't finish entering the {0} because some items or people became unavailable ({2_labelShort}). -->
-  <MessageCantLoadMoreIntoPortal>TODO</MessageCantLoadMoreIntoPortal>
+  <MessageCantLoadMoreIntoPortal>Ваши {1} не могут завершить проход в {lookup: {0}; Case; 3} из-за отсутствия доступа к некоторым людям или вещам: {2_labelShort}.</MessageCantLoadMoreIntoPortal>
   
   <!-- EN: Selected destination is invalid. -->
   <MessageTransportPodsDestinationIsInvalid>Выбрано неподходящее место назначения.</MessageTransportPodsDestinationIsInvalid>
@@ -577,9 +577,9 @@
   <!-- EN: {1}'s "{0}" can no longer count items in deleted stockpile {2}. -->
   <MessageBillValidationIncludeZoneDeleted>Невозможно посчитать число предметов, указанное для задачи «{0}», поскольку область {2} была удалена.</MessageBillValidationIncludeZoneDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted building {2}. -->
-  <MessageBillValidationIncludeBuildingDeleted>TODO</MessageBillValidationIncludeBuildingDeleted>
+  <MessageBillValidationIncludeBuildingDeleted>Невозможно посчитать число предметов в удалённом хранилище {2}.</MessageBillValidationIncludeBuildingDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in deleted storage group {2}. -->
-  <MessageBillValidationIncludeStorageGroupDeleted>TODO</MessageBillValidationIncludeStorageGroupDeleted>
+  <MessageBillValidationIncludeStorageGroupDeleted>Невозможно посчитать число предметов в удалённой группе хранилищ {2}.</MessageBillValidationIncludeStorageGroupDeleted>
   <!-- EN: {1}'s "{0}" can no longer count items in unavailable stockpile {2}. -->
   <MessageBillValidationIncludeZoneUnavailable>Невозможно посчитать число предметов, указанное для задачи «{0}», поскольку {2} вне досягаемости.</MessageBillValidationIncludeZoneUnavailable>
   <!-- EN: {1}'s "{0}" can no longer deliver all products to stockpile {2}. -->
@@ -751,7 +751,7 @@
   <!-- EN: must be colonist for the {0} role. -->
   <MessageRitualRoleMustBeColonist>До роли «{0}» допускаются только поселенцы.</MessageRitualRoleMustBeColonist>
   <!-- EN: must not be a prisoner for the {0} role. -->
-  <MessageRitualRoleMustBeFree>TODO</MessageRitualRoleMustBeFree>
+  <MessageRitualRoleMustBeFree>До роли «{0}» не допускаются пленники.</MessageRitualRoleMustBeFree>
   <!-- EN: {0_labelShort} won't attend due to extreme temperature in the ritual area. -->
   <MessageRitualWontAttendExtremeTemperature>{0_labelShort} не придёт из-за экстремальной температуры в месте проведения ритуала.</MessageRitualWontAttendExtremeTemperature>
   <!-- EN: must be colonist and not enslaved for the {0} role. -->
@@ -773,7 +773,7 @@
   <!-- EN: {0} cannot be a baby. -->
   <MessageRitualRoleCannotBeBaby>{0} не может быть младенцем.</MessageRitualRoleCannotBeBaby>
   <!-- EN: {0} is busy. -->
-  <MessageRitualRoleBusy>TODO</MessageRitualRoleBusy>
+  <MessageRitualRoleBusy>{0} {0_gender ? занят : занята}.</MessageRitualRoleBusy>
 
   <!-- EN: You must select a site to continue. -->
   <MessagePlayerMustSelectTile>Перед тем, как продолжить, выберите место.</MessagePlayerMustSelectTile>
@@ -804,22 +804,22 @@
   <NothingAvailableInCategory>Вы пока ничего не можете построить из этой категории</NothingAvailableInCategory>
 
   <!-- EN: Storage settings linked for {0} buildings. -->
-  <SettingsLinkedFor>Сгруппировано {0_numCase ? сооружение : сооружения : сооружений}.</SettingsLinkedFor>
+  <SettingsLinkedFor>Сгруппировано {0_numCase ? хранилище : хранилища : хранилищ}.</SettingsLinkedFor>
   <!-- EN: Storage settings linked for 1 building. -->
-  <SettingsLinkedForSingular>TODO</SettingsLinkedForSingular>
+  <SettingsLinkedForSingular>Сгруппировано 1 хранилище.</SettingsLinkedForSingular>
   <!-- EN: Storage settings unlinked for {0} buildings. -->
-  <SettingsUnlinkedFor>Группировка отменена для {0_numCase ? сооружения : сооружений : сооружений}.</SettingsUnlinkedFor>
+  <SettingsUnlinkedFor>Группировка отменена для {0_numCase ? хранилища : хранилищ : хранилищ}.</SettingsUnlinkedFor>
   <!-- EN: Storage settings unlinked for 1 building. -->
-  <SettingsUnlinkedForSingular>TODO</SettingsUnlinkedForSingular>
+  <SettingsUnlinkedForSingular>Группировка отменена для 1 хранилища.</SettingsUnlinkedForSingular>
   <!-- EN: Storage settings copied to clipboard. -->
   <StorageSettingsCopiedToClipboard>Настройки хранилища скопированы в буфер обмена.</StorageSettingsCopiedToClipboard>
   <!-- EN: Storage settings pasted from clipboard. -->
   <StorageSettingsPastedFromClipboard>Настройки хранилища вставлены из буфера обмена.</StorageSettingsPastedFromClipboard>
   
   <!-- EN: {0_label} requires adjacent walls to function. -->
-  <MessageBuildingRequiresAdjacentWalls>TODO</MessageBuildingRequiresAdjacentWalls>
+  <MessageBuildingRequiresAdjacentWalls>Для установки {lookup: {0_label}; Case; 1} нужны стены с обеих сторон.</MessageBuildingRequiresAdjacentWalls>
 
   <!-- EN: Cannot skip: Refugee -->
-  <MessageLodgersCantFarskip>TODO</MessageLodgersCantFarskip>
+  <MessageLodgersCantFarskip>Невозможно прыгнуть: беженец</MessageLodgersCantFarskip>
 
 </LanguageData>

--- a/Core/Keyed/Misc.xml
+++ b/Core/Keyed/Misc.xml
@@ -97,13 +97,13 @@
   <!-- EN: Translation -->
   <Translation>Перевод</Translation>
   <!-- EN: min(days) -->
-  <minDays>TODO</minDays>
+  <minDays>мин(дней)</minDays>
   <!-- EN: max(days) -->
-  <maxDays>TODO</maxDays>
+  <maxDays>макс(дней)</maxDays>
   <!-- EN: Processing -->
-  <Processing>TODO</Processing>
+  <Processing>Обработка</Processing>
   <!-- EN: Inspect -->
-  <Inspect>TODO</Inspect> 
+  <Inspect>Осмотреть</Inspect> 
 
   <!-- Content generation-->
   

--- a/Core/Keyed/Misc.xml
+++ b/Core/Keyed/Misc.xml
@@ -96,6 +96,14 @@
   <Uses>Использует</Uses> <!-- Использует: заряды / всего зарядов -->
   <!-- EN: Translation -->
   <Translation>Перевод</Translation>
+  <!-- EN: min(days) -->
+  <minDays>TODO</minDays>
+  <!-- EN: max(days) -->
+  <maxDays>TODO</maxDays>
+  <!-- EN: Processing -->
+  <Processing>TODO</Processing>
+  <!-- EN: Inspect -->
+  <Inspect>TODO</Inspect> 
 
   <!-- Content generation-->
   
@@ -201,6 +209,5 @@
   <!-- Legal status -->
   <!-- EN: colonist -->
   <Colonist>поселенец</Colonist>
-  
-  
+
 </LanguageData>


### PR DESCRIPTION
Второй реквест по Keyed-строкам

Помимо этого:

- Унифицировал перевод политики врачебного ухода и диеты на вкладке "Здоровье"
- Унифицировал перевод: "building"-"хранилище"
- Переделал переход через порталы, чтобы не было так:
![изображение](https://github.com/user-attachments/assets/0641b184-2721-412d-bcf2-0f24b1f0f0f5)

Close #1636